### PR TITLE
FBRef - replace 'season' data stat with 'year_id'

### DIFF
--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -130,7 +130,7 @@ class FBref(BaseRequestsReader):
             # extract season links
             tree = html.parse(reader)
             df_table = pd.read_html(etree.tostring(tree), attrs={"id": "seasons"})[0]
-            df_table["url"] = tree.xpath("//table[@id='seasons']//th[@data-stat='season']/a/@href")
+            df_table["url"] = tree.xpath("//table[@id='seasons']//th[@data-stat='year_id']/a/@href")
             seasons.append(df_table)
 
         df = (

--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -195,7 +195,7 @@ class FBref(BaseRequestsReader):
                 etree.tostring(tree), attrs={"id": f"stats_squads_{stat_type}_for"}
             )[0]
             df_table["url"] = tree.xpath(
-                f"//table[@id='stats_squads_{stat_type}_for']//th[@data-stat='squad']/a/@href"
+                f"//table[@id='stats_squads_{stat_type}_for']//th[@data-stat='team']/a/@href"
             )
             df_table["league"] = lkey
             df_table["season"] = skey

--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -130,7 +130,9 @@ class FBref(BaseRequestsReader):
             # extract season links
             tree = html.parse(reader)
             df_table = pd.read_html(etree.tostring(tree), attrs={"id": "seasons"})[0]
-            df_table["url"] = tree.xpath("//table[@id='seasons']//th[@data-stat='year_id']/a/@href")
+            df_table["url"] = tree.xpath(
+                "//table[@id='seasons']//th[@data-stat='year_id']/a/@href"
+            )
             seasons.append(df_table)
 
         df = (


### PR DESCRIPTION
FBRef appears to have switched to using `year_id` as the `data-stat` attribute on its seasons table.

This change allows the `read_seasons` function to return the expected seasons.

![Screenshot 2022-08-09 at 19 40 12](https://user-images.githubusercontent.com/19507676/183736451-729b1de8-319b-4b21-9158-066b6e052444.png)
