### PR TITLE
Faster scraping of player seasons stats - fbref.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v4.2.0
@@ -111,7 +111,7 @@ jobs:
     needs: tests
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
 
       - name: Set up Python
         uses: actions/setup-python@v4.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           print("::set-output name=result::{}".format(result))
 
       - name: Restore pre-commit cache
-        uses: actions/cache@v3.0.9
+        uses: actions/cache@v3.0.10
         if: matrix.session == 'pre-commit'
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: ${{ matrix.python }}
 
@@ -114,7 +114,7 @@ jobs:
         uses: actions/checkout@v3.1.0
 
       - name: Set up Python
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.9"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           print("::set-output name=result::{}".format(result))
 
       - name: Restore pre-commit cache
-        uses: actions/cache@v3.0.8
+        uses: actions/cache@v3.0.9
         if: matrix.session == 'pre-commit'
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3.0.2
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v4.2.0
+        uses: actions/setup-python@v4.3.0
         with:
           python-version: "3.8"
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-furo==2022.9.15
+furo==2022.9.29
 sphinx==4.5.0
 nbsphinx==0.8.9

--- a/poetry.lock
+++ b/poetry.lock
@@ -607,7 +607,7 @@ python-versions = "*"
 
 [[package]]
 name = "mypy"
-version = "0.981"
+version = "0.982"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
@@ -1569,7 +1569,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0.0"
-content-hash = "58a44ee8920ecb2390d8c387f21e194d6edbf62434dcaf048d0767b5efacfd77"
+content-hash = "986c2ad6e44004d84f87c13bed7f6232ea46d1f230ad99f4844a4c73a9143464"
 
 [metadata.files]
 alabaster = [
@@ -2041,30 +2041,30 @@ mistune = [
     {file = "mistune-0.8.4.tar.gz", hash = "sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e"},
 ]
 mypy = [
-    {file = "mypy-0.981-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:4bc460e43b7785f78862dab78674e62ec3cd523485baecfdf81a555ed29ecfa0"},
-    {file = "mypy-0.981-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:756fad8b263b3ba39e4e204ee53042671b660c36c9017412b43af210ddee7b08"},
-    {file = "mypy-0.981-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a16a0145d6d7d00fbede2da3a3096dcc9ecea091adfa8da48fa6a7b75d35562d"},
-    {file = "mypy-0.981-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce65f70b14a21fdac84c294cde75e6dbdabbcff22975335e20827b3b94bdbf49"},
-    {file = "mypy-0.981-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6e35d764784b42c3e256848fb8ed1d4292c9fc0098413adb28d84974c095b279"},
-    {file = "mypy-0.981-cp310-cp310-win_amd64.whl", hash = "sha256:e53773073c864d5f5cec7f3fc72fbbcef65410cde8cc18d4f7242dea60dac52e"},
-    {file = "mypy-0.981-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6ee196b1d10b8b215e835f438e06965d7a480f6fe016eddbc285f13955cca659"},
-    {file = "mypy-0.981-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ad21d4c9d3673726cf986ea1d0c9fb66905258709550ddf7944c8f885f208be"},
-    {file = "mypy-0.981-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d1debb09043e1f5ee845fa1e96d180e89115b30e47c5d3ce53bc967bab53f62d"},
-    {file = "mypy-0.981-cp37-cp37m-win_amd64.whl", hash = "sha256:9f362470a3480165c4c6151786b5379351b790d56952005be18bdbdd4c7ce0ae"},
-    {file = "mypy-0.981-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c9e0efb95ed6ca1654951bd5ec2f3fa91b295d78bf6527e026529d4aaa1e0c30"},
-    {file = "mypy-0.981-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e178eaffc3c5cd211a87965c8c0df6da91ed7d258b5fc72b8e047c3771317ddb"},
-    {file = "mypy-0.981-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:06e1eac8d99bd404ed8dd34ca29673c4346e76dd8e612ea507763dccd7e13c7a"},
-    {file = "mypy-0.981-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa38f82f53e1e7beb45557ff167c177802ba7b387ad017eab1663d567017c8ee"},
-    {file = "mypy-0.981-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:64e1f6af81c003f85f0dfed52db632817dabb51b65c0318ffbf5ff51995bbb08"},
-    {file = "mypy-0.981-cp38-cp38-win_amd64.whl", hash = "sha256:e1acf62a8c4f7c092462c738aa2c2489e275ed386320c10b2e9bff31f6f7e8d6"},
-    {file = "mypy-0.981-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:b6ede64e52257931315826fdbfc6ea878d89a965580d1a65638ef77cb551f56d"},
-    {file = "mypy-0.981-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eb3978b191b9fa0488524bb4ffedf2c573340e8c2b4206fc191d44c7093abfb7"},
-    {file = "mypy-0.981-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:77f8fcf7b4b3cc0c74fb33ae54a4cd00bb854d65645c48beccf65fa10b17882c"},
-    {file = "mypy-0.981-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f64d2ce043a209a297df322eb4054dfbaa9de9e8738291706eaafda81ab2b362"},
-    {file = "mypy-0.981-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2ee3dbc53d4df7e6e3b1c68ac6a971d3a4fb2852bf10a05fda228721dd44fae1"},
-    {file = "mypy-0.981-cp39-cp39-win_amd64.whl", hash = "sha256:8e8e49aa9cc23aa4c926dc200ce32959d3501c4905147a66ce032f05cb5ecb92"},
-    {file = "mypy-0.981-py3-none-any.whl", hash = "sha256:794f385653e2b749387a42afb1e14c2135e18daeb027e0d97162e4b7031210f8"},
-    {file = "mypy-0.981.tar.gz", hash = "sha256:ad77c13037d3402fbeffda07d51e3f228ba078d1c7096a73759c9419ea031bf4"},
+    {file = "mypy-0.982-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5085e6f442003fa915aeb0a46d4da58128da69325d8213b4b35cc7054090aed5"},
+    {file = "mypy-0.982-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:41fd1cf9bc0e1c19b9af13a6580ccb66c381a5ee2cf63ee5ebab747a4badeba3"},
+    {file = "mypy-0.982-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f793e3dd95e166b66d50e7b63e69e58e88643d80a3dcc3bcd81368e0478b089c"},
+    {file = "mypy-0.982-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86ebe67adf4d021b28c3f547da6aa2cce660b57f0432617af2cca932d4d378a6"},
+    {file = "mypy-0.982-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:175f292f649a3af7082fe36620369ffc4661a71005aa9f8297ea473df5772046"},
+    {file = "mypy-0.982-cp310-cp310-win_amd64.whl", hash = "sha256:8ee8c2472e96beb1045e9081de8e92f295b89ac10c4109afdf3a23ad6e644f3e"},
+    {file = "mypy-0.982-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58f27ebafe726a8e5ccb58d896451dd9a662a511a3188ff6a8a6a919142ecc20"},
+    {file = "mypy-0.982-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6af646bd46f10d53834a8e8983e130e47d8ab2d4b7a97363e35b24e1d588947"},
+    {file = "mypy-0.982-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e7aeaa763c7ab86d5b66ff27f68493d672e44c8099af636d433a7f3fa5596d40"},
+    {file = "mypy-0.982-cp37-cp37m-win_amd64.whl", hash = "sha256:724d36be56444f569c20a629d1d4ee0cb0ad666078d59bb84f8f887952511ca1"},
+    {file = "mypy-0.982-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14d53cdd4cf93765aa747a7399f0961a365bcddf7855d9cef6306fa41de01c24"},
+    {file = "mypy-0.982-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:26ae64555d480ad4b32a267d10cab7aec92ff44de35a7cd95b2b7cb8e64ebe3e"},
+    {file = "mypy-0.982-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6389af3e204975d6658de4fb8ac16f58c14e1bacc6142fee86d1b5b26aa52bda"},
+    {file = "mypy-0.982-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b35ce03a289480d6544aac85fa3674f493f323d80ea7226410ed065cd46f206"},
+    {file = "mypy-0.982-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c6e564f035d25c99fd2b863e13049744d96bd1947e3d3d2f16f5828864506763"},
+    {file = "mypy-0.982-cp38-cp38-win_amd64.whl", hash = "sha256:cebca7fd333f90b61b3ef7f217ff75ce2e287482206ef4a8b18f32b49927b1a2"},
+    {file = "mypy-0.982-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a705a93670c8b74769496280d2fe6cd59961506c64f329bb179970ff1d24f9f8"},
+    {file = "mypy-0.982-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:75838c649290d83a2b83a88288c1eb60fe7a05b36d46cbea9d22efc790002146"},
+    {file = "mypy-0.982-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:91781eff1f3f2607519c8b0e8518aad8498af1419e8442d5d0afb108059881fc"},
+    {file = "mypy-0.982-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaa97b9ddd1dd9901a22a879491dbb951b5dec75c3b90032e2baa7336777363b"},
+    {file = "mypy-0.982-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a692a8e7d07abe5f4b2dd32d731812a0175626a90a223d4b58f10f458747dd8a"},
+    {file = "mypy-0.982-cp39-cp39-win_amd64.whl", hash = "sha256:eb7a068e503be3543c4bd329c994103874fa543c1727ba5288393c21d912d795"},
+    {file = "mypy-0.982-py3-none-any.whl", hash = "sha256:1021c241e8b6e1ca5a47e4d52601274ac078a89845cfde66c6d5f769819ffa1d"},
+    {file = "mypy-0.982.tar.gz", hash = "sha256:85f7a343542dc8b1ed0a888cdd34dca56462654ef23aa673907305b260b3d746"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ undetected-chromedriver = "^3.1.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.0.0"
-mypy = "^0.981"
+mypy = "^0.982"
 pylint = "^2.6.0"
 pytest-deadfixtures = "^2.2.1"
 unify = "^0.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "soccerdata"
-version = "1.1.1"
+version = "1.1.0"
 description = "A collection of wrappers over soccer data from various websites / APIs."
 authors = ["Pieter Robberechts <pieter.robberechts@kuleuven.be>"]
 license = "Apache-2.0"

--- a/soccerdata/_config.py
+++ b/soccerdata/_config.py
@@ -146,13 +146,6 @@ LEAGUE_DICT = {
         "season_end": "May",
     },
 }
-BIG_FIVE_DICT = {
-    "it Serie A": "ITA-Serie A",
-    "fr Ligue 1": "FRA-Ligue 1",
-    "es La Liga": "ESP-La Liga",
-    "eng Premier League": "ENG-Premier League",
-    "de Bundesliga": "GER-Bundesliga",
-}
 _f_custom_league_dict = CONFIG_DIR / "league_dict.json"
 if _f_custom_league_dict.is_file():
     with open(_f_custom_league_dict, encoding='utf8') as json_file:

--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -14,7 +14,6 @@ from ._common import (
     standardize_colnames,
 )
 from ._config import (
-    BIG_FIVE_DICT,
     DATA_DIR,
     LEAGUE_DICT,
     NOCACHE,
@@ -25,6 +24,14 @@ from ._config import (
 
 FBREF_DATADIR = DATA_DIR / "FBref"
 FBREF_API = "https://fbref.com"
+
+BIG_FIVE_DICT = {
+    "it Serie A": "ITA-Serie A",
+    "fr Ligue 1": "FRA-Ligue 1",
+    "es La Liga": "ESP-La Liga",
+    "eng Premier League": "ENG-Premier League",
+    "de Bundesliga": "GER-Bundesliga",
+}
 
 
 class FBref(BaseRequestsReader):
@@ -283,7 +290,7 @@ class FBref(BaseRequestsReader):
         filemask = "teams_{}_{}.html"
 
         if stat_type not in self.valid_player:
-            raise TypeError(f'Invalid argument: stat_type should be in {self.valid_player}')
+            raise TypeError(f"Invalid argument: stat_type should be in {self.valid_player}")
 
         # get league IDs
         seasons = self.read_seasons()
@@ -361,15 +368,15 @@ class FBref(BaseRequestsReader):
         filemask = "players_{}_{}_{}.html"
 
         if stat_type not in self.valid_player:
-            raise TypeError(f'Invalid argument: stat_type should be in {self.valid_player}')
+            raise TypeError(f"Invalid argument: stat_type should be in {self.valid_player}")
 
         # get league IDs
         if self.big_five:
             seasons = self.read_big_five_seasons()
-            sub_page = '/players'
+            sub_page = "/players"
         else:
             seasons = self.read_seasons()
-            sub_page = ''
+            sub_page = ""
 
         if stat_type == "standard":
             page = "stats"
@@ -640,7 +647,7 @@ class FBref(BaseRequestsReader):
         filemask = "match_{}.html"
 
         if stat_type not in self.valid_match:
-            raise TypeError(f'Invalid argument: stat_type should be in {self.valid_match}')
+            raise TypeError(f"Invalid argument: stat_type should be in {self.valid_match}")
 
         # Retrieve games for which a match report is available
         df_schedule = self.read_schedule(force_cache).reset_index()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,31 +8,31 @@ import soccerdata as foo
 @pytest.fixture
 def five38():
     """Return a correctly initialized instance of FiveThirtyEight."""
-    return foo.FiveThirtyEight(seasons=2021)
+    return foo.FiveThirtyEight(seasons="20-21")
 
 
 @pytest.fixture
 def five38_laliga():
     """Return a correctly initialized instance of FiveThirtyEight filtered by league: La Liga."""
-    return foo.FiveThirtyEight("ESP-La Liga", 2021)
+    return foo.FiveThirtyEight("ESP-La Liga", "20-21")
 
 
 @pytest.fixture
 def espn_seriea():
     """Return a correctly initialized instance of ESPN filtered by league: Serie A."""
-    return foo.ESPN("ITA-Serie A", 2021)
+    return foo.ESPN("ITA-Serie A", "20-21")
 
 
 @pytest.fixture
 def sofifa_bundesliga():
     """Return a correctly initialized instance of SoFIFA filtered by league: Bundesliga."""
-    return foo.SoFIFA("GER-Bundesliga", 2021)
+    return foo.SoFIFA("GER-Bundesliga", "20-21")
 
 
 @pytest.fixture
 def fbref_ligue1():
     """Return a correctly initialized instance of FBref filtered by league: Ligue 1."""
-    return foo.FBref("FRA-Ligue 1", 2021)
+    return foo.FBref("FRA-Ligue 1", "20-21")
 
 
 @pytest.fixture
@@ -50,4 +50,4 @@ def match_epl_2y():
 @pytest.fixture
 def whoscored():
     """Return a correctly initialized instance of WhoScored."""
-    return foo.WhoScored("ENG-Premier League", 2021)
+    return foo.WhoScored("ENG-Premier League", "20-21")

--- a/tests/test_FBref.py
+++ b/tests/test_FBref.py
@@ -3,6 +3,8 @@
 import pandas as pd
 import pytest
 
+import soccerdata as sd
+
 # Unittests -------------------------------------------------------------------
 # Happy flow
 
@@ -75,3 +77,55 @@ def test_read_shot_events(fbref_ligue1):
 
 def test_read_lineup(fbref_ligue1):
     assert isinstance(fbref_ligue1.read_lineup(match_id="796787da"), pd.DataFrame)
+
+
+def test_combine_big5():
+    fbref_bigfive = sd.FBref(["Big 5 European Leagues Combined"], 2021)
+    assert len(fbref_bigfive.read_leagues()) == 1
+    assert len(fbref_bigfive.read_seasons()) == 1
+
+@pytest.mark.parametrize(
+    "stat_type",
+    [
+        "standard",
+        "keeper",
+        "keeper_adv",
+        "shooting",
+        "passing",
+        "passing_types",
+        "goal_shot_creation",
+        "defense",
+        "possession",
+        "playing_time",
+        "misc",
+    ],
+)
+def test_combine_big5_team_season_stats(fbref_ligue1, stat_type):
+    fbref_bigfive = sd.FBref(["Big 5 European Leagues Combined"], 2021)
+    pd.testing.assert_frame_equal(
+        fbref_bigfive.read_team_season_stats(stat_type).loc["FRA-Ligue 1"],
+        fbref_ligue1.read_team_season_stats(stat_type).loc["FRA-Ligue 1"],
+    )
+
+@pytest.mark.parametrize(
+    "stat_type",
+    [
+        "standard",
+        "shooting",
+        "passing",
+        "passing_types",
+        "goal_shot_creation",
+        "defense",
+        "possession",
+        "playing_time",
+        "misc",
+        "keeper",
+        "keeper_adv",
+    ],
+)
+def test_combine_big5_player_season_stats(fbref_ligue1, stat_type):
+    fbref_bigfive = sd.FBref(["Big 5 European Leagues Combined"], 2021)
+    pd.testing.assert_frame_equal(
+        fbref_bigfive.read_player_season_stats(stat_type).loc["FRA-Ligue 1"],
+        fbref_ligue1.read_player_season_stats(stat_type).loc["FRA-Ligue 1"],
+    )

--- a/tests/test_FBref.py
+++ b/tests/test_FBref.py
@@ -84,6 +84,7 @@ def test_combine_big5():
     assert len(fbref_bigfive.read_leagues()) == 1
     assert len(fbref_bigfive.read_seasons()) == 1
 
+
 @pytest.mark.parametrize(
     "stat_type",
     [
@@ -106,6 +107,7 @@ def test_combine_big5_team_season_stats(fbref_ligue1, stat_type):
         fbref_bigfive.read_team_season_stats(stat_type).loc["FRA-Ligue 1"],
         fbref_ligue1.read_team_season_stats(stat_type).loc["FRA-Ligue 1"],
     )
+
 
 @pytest.mark.parametrize(
     "stat_type",

--- a/tests/test_FBref.py
+++ b/tests/test_FBref.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import soccerdata as sd
+from soccerdata.fbref import _concat
 
 # Unittests -------------------------------------------------------------------
 # Happy flow
@@ -103,9 +104,14 @@ def test_combine_big5():
 )
 def test_combine_big5_team_season_stats(fbref_ligue1, stat_type):
     fbref_bigfive = sd.FBref(["Big 5 European Leagues Combined"], 2021)
+    ligue1 = fbref_ligue1.read_team_season_stats(stat_type).loc["FRA-Ligue 1"]
+    bigfive = fbref_bigfive.read_team_season_stats(stat_type).loc["FRA-Ligue 1"]
+    cols = _concat([ligue1, bigfive]).columns
+    ligue1.columns = cols
+    bigfive.columns = cols
     pd.testing.assert_frame_equal(
-        fbref_bigfive.read_team_season_stats(stat_type).loc["FRA-Ligue 1"],
-        fbref_ligue1.read_team_season_stats(stat_type).loc["FRA-Ligue 1"],
+        ligue1,
+        bigfive,
     )
 
 
@@ -127,7 +133,12 @@ def test_combine_big5_team_season_stats(fbref_ligue1, stat_type):
 )
 def test_combine_big5_player_season_stats(fbref_ligue1, stat_type):
     fbref_bigfive = sd.FBref(["Big 5 European Leagues Combined"], 2021)
+    ligue1 = fbref_ligue1.read_player_season_stats(stat_type).loc["FRA-Ligue 1"]
+    bigfive = fbref_bigfive.read_player_season_stats(stat_type).loc["FRA-Ligue 1"]
+    cols = _concat([ligue1, bigfive]).columns
+    ligue1.columns = cols
+    bigfive.columns = cols
     pd.testing.assert_frame_equal(
-        fbref_bigfive.read_player_season_stats(stat_type).loc["FRA-Ligue 1"],
-        fbref_ligue1.read_player_season_stats(stat_type).loc["FRA-Ligue 1"],
+        ligue1,
+        bigfive,
     )


### PR DESCRIPTION
I am having another go at this [previous attempt #69] because you have updated the FBRef class to use the league pages. I have tried this against all stat_types for 2020-2021 and it seems to work

- Amended the FBRef scraper so it uses the Big 5 pages if all five leagues are requested.
- Added some type checks for the stats_type argument.

I am not able to run the tests locally, but I'll try to fix anything that doesn't work after.