### PR TITLE
[MatchHistory] Drop empty cols

### DIFF
--- a/soccerdata/match_history.py
+++ b/soccerdata/match_history.py
@@ -117,6 +117,7 @@ class MatchHistory(BaseRequestsReader):
             .dropna(subset=['home_team', 'away_team'])
         )
 
+        df = df.loc[:, ~df.columns.str.contains('^Unnamed')]
         df['game'] = df.apply(make_game_id, axis=1)
         df.set_index(['league', 'season', 'game'], inplace=True)
         df.sort_index(inplace=True)


### PR DESCRIPTION
The CSV files provided by football-data.co.uk sometimes contain a few empty columns at the end. These are now dropped from the output dataframe.