### PR TITLE
[FBref] Fix invalid cache filenames in read_team_season_stats

### DIFF
--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -280,9 +280,7 @@ class FBref(BaseRequestsReader):
             big_five = lkey == "Big 5 European Leagues Combined"
             tournament = season["format"] == "elimination"
             # read html page (league overview)
-            filepath = self.data_dir / filemask.format(
-                lkey, skey, stat_type if big_five else "all"
-            )
+            filepath = self.data_dir / filemask.format(lkey, skey, stat_type if big_five else page)
             url = (
                 FBREF_API
                 + "/".join(season.url.split("/")[:-1])


### PR DESCRIPTION
The filename for the cached team season stats was appended with "all", regardless of the type of stats queried. This caused an issue as the cache might not have contained the table needed. It now caches these tables in different files.