### PR TITLE
Changed logic in _concat to fix error thrown on forfeited matches

### DIFF
--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -2,7 +2,6 @@
 import itertools
 import warnings
 from datetime import date, datetime
-from functools import reduce
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
 

--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -1091,15 +1091,12 @@ def _concat(dfs: List[pd.DataFrame]) -> pd.DataFrame:
         mask = columns[0].str.startswith("Unnamed:").fillna(False)
         columns.loc[mask, 0] = None
         all_columns.append(columns)
-    columns = reduce(lambda left, right: left.combine_first(right), all_columns)
 
-    # Move the remaining missing columns back to level 1 and replace with empyt string
-    if columns.shape[1] == 2:
-        mask = pd.isnull(columns[0])
-        columns.loc[mask, [0, 1]] = columns.loc[mask, [1, 0]].values
-        columns.loc[mask, 1] = ""
-
-        for df in dfs:
+        # Move the remaining missing columns back to level 1 and replace with empyt string
+        if columns.shape[1] == 2:
+            mask = pd.isnull(columns[0])
+            columns.loc[mask, [0, 1]] = columns.loc[mask, [1, 0]].values
+            columns.loc[mask, 1] = ""
             df.columns = pd.MultiIndex.from_tuples(columns.to_records(index=False).tolist())
 
     return pd.concat(dfs)

--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -1078,7 +1078,6 @@ def _concat(dfs: List[pd.DataFrame]) -> pd.DataFrame:
         Concatenated dataframe with uniform column names.
     """
     # Look for the most complete level 0 columns
-    all_columns = []
     for df in dfs:
         columns = pd.DataFrame(df.columns.tolist())
         # Move missing columns to level 0
@@ -1089,8 +1088,6 @@ def _concat(dfs: List[pd.DataFrame]) -> pd.DataFrame:
         # Rename unnamed columns
         mask = columns[0].str.startswith("Unnamed:").fillna(False)
         columns.loc[mask, 0] = None
-        all_columns.append(columns)
-
         # Move the remaining missing columns back to level 1 and replace with empyt string
         if columns.shape[1] == 2:
             mask = pd.isnull(columns[0])


### PR DESCRIPTION
`_concat` would throw an error when analysing [Tottenham-Rennes](https://fbref.com/en/matches/d69a0a11/Tottenham-Hotspur-Rennes-December-9-2021-Europa-Conference-League), as the game was forfeited and, therefore, there is no match data available for it. The dataframe resulting from this page had fewer columns than the ones for other games in the competition, thus throwing an error.