### PR TITLE
[FBref] Informative errors when merge fails

### DIFF
--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -305,7 +305,7 @@ class FBref(BaseRequestsReader):
 
         # return data frame
         df = (
-            _concat(teams)
+            _concat(teams, key=['league', 'season'])
             .rename(columns={"Squad": "team", "# Pl": "players_used"})
             .replace({"team": TEAMNAME_REPLACEMENTS})
             # .pipe(standardize_colnames)
@@ -438,7 +438,7 @@ class FBref(BaseRequestsReader):
 
         # return data frame
         df = (
-            _concat(stats)
+            _concat(stats, key=['league', 'season', 'team'])
             .replace(
                 {
                     "Opponent": TEAMNAME_REPLACEMENTS,
@@ -577,7 +577,7 @@ class FBref(BaseRequestsReader):
             players.append(df_table)
 
         # return dataframe
-        df = _concat(players)
+        df = _concat(players, key=["league", "season"])
         df = df[df.Player != "Player"]
         df = (
             df.drop("Matches", axis=1, level=0)
@@ -788,7 +788,7 @@ class FBref(BaseRequestsReader):
             else:
                 logger.warning("No stats found for away team for game with id=%s", game["game_id"])
 
-        df = _concat(stats)
+        df = _concat(stats, key=['game'])
         df = df[~df.Player.str.contains(r"^\d+\sPlayers$")]
         df = (
             df.rename(columns={"#": "jersey_number"})
@@ -960,7 +960,7 @@ class FBref(BaseRequestsReader):
             return pd.DataFrame()
 
         df = (
-            _concat(events)
+            pd.concat(events)
             .replace({"team": TEAMNAME_REPLACEMENTS})
             .set_index(["league", "season", "game"])
             .sort_index()
@@ -1014,7 +1014,7 @@ class FBref(BaseRequestsReader):
         shots = []
         for i, game in iterator.reset_index().iterrows():
             url = urlmask.format(game["game_id"])
-            # get league and season
+            # get league anigd season
             logger.info(
                 "[%s/%s] Retrieving game with id=%s", i + 1, len(iterator), game["game_id"]
             )
@@ -1035,7 +1035,7 @@ class FBref(BaseRequestsReader):
             return pd.DataFrame()
 
         df = (
-            _concat(shots)
+            _concat(shots, key=['game'])
             .rename(columns={"Squad": "team"})
             .replace({"team": TEAMNAME_REPLACEMENTS})
             .pipe(
@@ -1075,45 +1075,103 @@ def _parse_table(html_table: html.HtmlElement) -> pd.DataFrame:
     return df_table.convert_dtypes()
 
 
-def _concat(dfs: List[pd.DataFrame]) -> pd.DataFrame:
+def _concat(dfs: List[pd.DataFrame], key: List[str]) -> pd.DataFrame:
     """Merge matching tables scraped from different pages.
 
-    The level 0 headers are not consitent across seasons and leagues, this
+    The level 0 headers are not consistent across seasons and leagues, this
     function tries to determine uniform column names.
 
     Parameters
     ----------
     dfs : list(pd.DataFrame)
         Input dataframes.
+    key : list(str)
+        List of columns that uniquely identify each df.
+
+    Raises
+    ------
+    RuntimeError
+        If the dfs cannot be merged due to the columns not matching each other.
 
     Returns
     -------
     pd.DataFrame
         Concatenated dataframe with uniform column names.
     """
-    # Look for the most complete level 0 columns
     all_columns = []
+
+    # Step 1: Clean up the columns of each dataframe that should be merged
     for df in dfs:
         columns = pd.DataFrame(df.columns.tolist())
-        # Move missing columns to level 0
+        # Set "Unnamed: ..." column names to None
+        columns.replace(to_replace=r"^Unnamed:.*", value=None, regex=True, inplace=True)
         if columns.shape[1] == 2:
-            columns.replace({"": None}, inplace=True)
+            # Set "" column names to None
+            columns.replace(to_replace="", value=None, inplace=True)
+            # Move None column names to level 0
             mask = pd.isnull(columns[1])
             columns.loc[mask, [0, 1]] = columns.loc[mask, [1, 0]].values
-        # Rename unnamed columns
-        mask = columns[0].str.startswith("Unnamed:").fillna(False)
-        columns.loc[mask, 0] = None
+        # We'll try to replace some the None values in step 2
         all_columns.append(columns)
+        # But for now, we assume that we cannot replace them and move all
+        # missing columns to level 1 and replace them with the empty string
+        if columns.shape[1] == 2:
+            mask = pd.isnull(columns[0])
+            columns.loc[mask, [0, 1]] = columns.loc[mask, [1, 0]].values
+            columns.loc[mask, 1] = ""
+        df.columns = pd.MultiIndex.from_tuples(columns.to_records(index=False).tolist())
+
+    # all dataframes should now have the same length and level 1 columns
+    for i, columns in enumerate(all_columns):
+        if not columns[1].equals(all_columns[0][1]):
+            res = all_columns[0].merge(columns, indicator=True, how='outer')
+            raise RuntimeError(
+                (
+                    "Cannot merge the data for {firs} and {cur}.\n\n"
+                    + "The following columns are missing in {first}: {extra_cols}.\n\n"
+                    + "The following columns are missing in {cur}: {missing_cols}.\n\n"
+                    + "Please try to scrape the data again with caching disabled."
+                ).format(
+                    first=dfs[0].loc[0, key].values,
+                    cur=dfs[i].loc[0, key].values,
+                    extra_cols=", ".join(
+                        map(
+                            str,
+                            res.loc[res['_merge'] == "left_only", [0, 1]]
+                            .to_records(index=False)
+                            .tolist(),
+                        )
+                    ),
+                    missing_cols=", ".join(
+                        map(
+                            str,
+                            res.loc[res['_merge'] == "right_only", [0, 1]]
+                            .to_records(index=False)
+                            .tolist(),
+                        )
+                    ),
+                ),
+            )
+
+    # Step 2: Look for the most complete level 0 columns
     columns = reduce(lambda left, right: left.combine_first(right), all_columns)
 
-    # Move the remaining missing columns back to level 1 and replace with empyt string
+    # Step 3: Make sure columns are consistent
     if columns.shape[1] == 2:
         mask = pd.isnull(columns[0])
         columns.loc[mask, [0, 1]] = columns.loc[mask, [1, 0]].values
         columns.loc[mask, 1] = ""
+        column_idx = pd.MultiIndex.from_tuples(columns.to_records(index=False).tolist())
 
         for df in dfs:
-            df.columns = pd.MultiIndex.from_tuples(columns.to_records(index=False).tolist())
+            if df.columns.equals(column_idx):
+                # This dataframe already has the uniform column index
+                pass
+            elif len(df.columns) == len(column_idx):
+                # This dataframe has the same number of columns and the same
+                # level 1 columns, we assume that the level 0 columns can be
+                # replaced
+                df.columns = column_idx
 
     return pd.concat(dfs)
 

--- a/tests/test_FBref.py
+++ b/tests/test_FBref.py
@@ -122,9 +122,9 @@ def test_combine_big5() -> None:
 )
 def test_combine_big5_team_season_stats(fbref_ligue1: FBref, stat_type: str) -> None:
     fbref_bigfive = sd.FBref(["Big 5 European Leagues Combined"], 2021)
-    ligue1 = fbref_ligue1.read_team_season_stats(stat_type).loc["FRA-Ligue 1"]
-    bigfive = fbref_bigfive.read_team_season_stats(stat_type).loc["FRA-Ligue 1"]
-    cols = _concat([ligue1, bigfive]).columns
+    ligue1 = fbref_ligue1.read_team_season_stats(stat_type).loc["FRA-Ligue 1"].reset_index()
+    bigfive = fbref_bigfive.read_team_season_stats(stat_type).loc["FRA-Ligue 1"].reset_index()
+    cols = _concat([ligue1, bigfive], key=["season"]).columns
     ligue1.columns = cols
     bigfive.columns = cols
     pd.testing.assert_frame_equal(
@@ -151,9 +151,9 @@ def test_combine_big5_team_season_stats(fbref_ligue1: FBref, stat_type: str) -> 
 )
 def test_combine_big5_player_season_stats(fbref_ligue1: FBref, stat_type: str) -> None:
     fbref_bigfive = sd.FBref(["Big 5 European Leagues Combined"], 2021)
-    ligue1 = fbref_ligue1.read_player_season_stats(stat_type).loc["FRA-Ligue 1"]
-    bigfive = fbref_bigfive.read_player_season_stats(stat_type).loc["FRA-Ligue 1"]
-    cols = _concat([ligue1, bigfive]).columns
+    ligue1 = fbref_ligue1.read_player_season_stats(stat_type).loc["FRA-Ligue 1"].reset_index()
+    bigfive = fbref_bigfive.read_player_season_stats(stat_type).loc["FRA-Ligue 1"].reset_index()
+    cols = _concat([ligue1, bigfive], key=["season"]).columns
     ligue1.columns = cols
     bigfive.columns = cols
     pd.testing.assert_frame_equal(


### PR DESCRIPTION
The FBref scraper attempts to merge data from multiple games, seasons, etc. in a single DataFrame. Sometimes this automatic merge fails, in which case a cryptic error is thrown. Now, a more informative error message is printed listing the additional and/or missing columns and with the suggestion to clear the cache (a common cause is merging new with outdated cached data).

Fixes #161