### PR TITLE
Handle canceled / forfeited games

### DIFF
--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -2,7 +2,6 @@
 import itertools
 import warnings
 from datetime import date, datetime
-from functools import reduce
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
 

--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -2,6 +2,7 @@
 import itertools
 import warnings
 from datetime import date, datetime
+from functools import reduce
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
 

--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -1127,37 +1127,38 @@ def _concat(dfs: List[pd.DataFrame], key: List[str]) -> pd.DataFrame:
             df.columns = pd.MultiIndex.from_tuples(columns.to_records(index=False).tolist())
 
     # throw a warning if not all dataframes have the same length and level 1 columns
-    for i, columns in enumerate(all_columns):
-        if not columns[1].equals(all_columns[0][1]):
-            res = all_columns[0].merge(columns, indicator=True, how='outer')
-            warnings.warn(
-                (
-                    "Different columns found for {first} and {cur}.\n\n"
-                    + "The following columns are missing in {first}: {extra_cols}.\n\n"
-                    + "The following columns are missing in {cur}: {missing_cols}.\n\n"
-                    + "The columns of the dataframe with the most columns will be used."
-                ).format(
-                    first=dfs[0].iloc[:1][key].values,
-                    cur=dfs[i].iloc[:1][key].values,
-                    extra_cols=", ".join(
-                        map(
-                            str,
-                            res.loc[res['_merge'] == "left_only", [0, 1]]
-                            .to_records(index=False)
-                            .tolist(),
-                        )
+    if len(all_columns) and all_columns[0].shape[1] == 2:
+        for i, columns in enumerate(all_columns):
+            if not columns[1].equals(all_columns[0][1]):
+                res = all_columns[0].merge(columns, indicator=True, how='outer')
+                warnings.warn(
+                    (
+                        "Different columns found for {first} and {cur}.\n\n"
+                        + "The following columns are missing in {first}: {extra_cols}.\n\n"
+                        + "The following columns are missing in {cur}: {missing_cols}.\n\n"
+                        + "The columns of the dataframe with the most columns will be used."
+                    ).format(
+                        first=dfs[0].iloc[:1][key].values,
+                        cur=dfs[i].iloc[:1][key].values,
+                        extra_cols=", ".join(
+                            map(
+                                str,
+                                res.loc[res['_merge'] == "left_only", [0, 1]]
+                                .to_records(index=False)
+                                .tolist(),
+                            )
+                        ),
+                        missing_cols=", ".join(
+                            map(
+                                str,
+                                res.loc[res['_merge'] == "right_only", [0, 1]]
+                                .to_records(index=False)
+                                .tolist(),
+                            )
+                        ),
                     ),
-                    missing_cols=", ".join(
-                        map(
-                            str,
-                            res.loc[res['_merge'] == "right_only", [0, 1]]
-                            .to_records(index=False)
-                            .tolist(),
-                        )
-                    ),
-                ),
-                stacklevel=1,
-            )
+                    stacklevel=1,
+                )
 
     if len(all_columns) and all_columns[0].shape[1] == 2:
         # Step 2: Look for the most complete level 0 columns

--- a/tests/test_FBref.py
+++ b/tests/test_FBref.py
@@ -132,12 +132,8 @@ def test_concat_with_forfeited_game() -> None:
     fbref_seriea = sd.FBref(["ITA-Serie A"], 2021)
     df_1 = fbref_seriea.read_player_match_stats(match_id=["e0a20cfe", "34e95e35"])
     df_2 = fbref_seriea.read_player_match_stats(match_id=["34e95e35", "e0a20cfe"])
-    assert isinstance(
-        df_1, pd.DataFrame
-    )
-    assert isinstance(
-        df_2, pd.DataFrame
-    )
+    assert isinstance(df_1, pd.DataFrame)
+    assert isinstance(df_2, pd.DataFrame)
     # Regardless of the order in which the matches are read, the result should be the same.
     assert df_1.equals(df_2)
 

--- a/tests/test_FBref.py
+++ b/tests/test_FBref.py
@@ -143,6 +143,13 @@ def test_concat_not_matching_columns() -> None:
         _concat([df1, df2], key=["player"])
 
 
+def test_concat_forfeited_games() -> None:
+    fbref_seriea = sd.FBref(["ITA-Serie A"], 2021)
+    assert isinstance(
+        fbref_seriea.read_player_match_stats(match_id=["34e95e35", "e0a20cfe"]), pd.DataFrame
+    )
+
+
 def test_combine_big5() -> None:
     fbref_bigfive = sd.FBref(["Big 5 European Leagues Combined"], 2021)
     assert len(fbref_bigfive.read_leagues()) == 1

--- a/tests/test_FBref.py
+++ b/tests/test_FBref.py
@@ -131,11 +131,11 @@ def test_concat() -> None:
 def test_concat_with_forfeited_game() -> None:
     fbref_seriea = sd.FBref(["ITA-Serie A"], 2021)
     df_1 = fbref_seriea.read_player_match_stats(match_id=["e0a20cfe", "34e95e35"])
-    df_2 = fbref_seriea.read_player_match_stats(match_id=["34e95e35", "e0a20cfe"])
+    df_2 = fbref_seriea.read_player_match_stats(match_id=["e0a20cfe", "a3e10e13"])
     assert isinstance(df_1, pd.DataFrame)
     assert isinstance(df_2, pd.DataFrame)
     # Regardless of the order in which the matches are read, the result should be the same.
-    assert df_1.equals(df_2)
+    assert df_1.columns.equals(df_2.columns)
 
 
 def test_combine_big5() -> None:

--- a/tests/test_FBref.py
+++ b/tests/test_FBref.py
@@ -128,25 +128,10 @@ def test_concat() -> None:
     )
 
 
-def test_concat_not_matching_columns() -> None:
-    df1 = pd.DataFrame(
-        columns=pd.MultiIndex.from_tuples(
-            [("Unnamed: a", "player"), ("Performance", "Goals"), ("Performance", "Assists")]
-        )
-    )
-    df2 = pd.DataFrame(
-        columns=pd.MultiIndex.from_tuples(
-            [("Unnamed: a", "player"), ("Unnamed: b", "Goals"), ("Performance", "Fouls")]
-        )
-    )
-    with pytest.raises(RuntimeError):
-        _concat([df1, df2], key=["player"])
-
-
-def test_concat_forfeited_games() -> None:
+def test_concat_with_forfeited_game() -> None:
     fbref_seriea = sd.FBref(["ITA-Serie A"], 2021)
     assert isinstance(
-        fbref_seriea.read_player_match_stats(match_id=["34e95e35", "e0a20cfe"]), pd.DataFrame
+        fbref_seriea.read_player_match_stats(match_id=["e0a20cfe", "34e95e35"]), pd.DataFrame
     )
 
 

--- a/tests/test_FBref.py
+++ b/tests/test_FBref.py
@@ -130,9 +130,16 @@ def test_concat() -> None:
 
 def test_concat_with_forfeited_game() -> None:
     fbref_seriea = sd.FBref(["ITA-Serie A"], 2021)
+    df_1 = fbref_seriea.read_player_match_stats(match_id=["e0a20cfe", "34e95e35"])
+    df_2 = fbref_seriea.read_player_match_stats(match_id=["34e95e35", "e0a20cfe"])
     assert isinstance(
-        fbref_seriea.read_player_match_stats(match_id=["e0a20cfe", "34e95e35"]), pd.DataFrame
+        df_1, pd.DataFrame
     )
+    assert isinstance(
+        df_2, pd.DataFrame
+    )
+    # Regardless of the order in which the matches are read, the result should be the same.
+    assert df_1.equals(df_2)
 
 
 def test_combine_big5() -> None:


### PR DESCRIPTION
_concat would throw an error when analysing [Tottenham-Rennes](https://fbref.com/en/matches/d69a0a11/Tottenham-Hotspur-Rennes-December-9-2021-Europa-Conference-League), as the game was forfeited and, therefore, there is no match data available for it. The dataframe resulting from this page had fewer columns than the ones for other games in the competition, thus throwing an error.

This is a new attempt to solve #304.