### PR TITLE
Handle Selenium 4.13 no longer supporting headless

### DIFF
--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -13,8 +13,10 @@ from typing import IO, Callable, Dict, Iterable, List, Optional, Union
 import numpy as np
 import pandas as pd
 import requests
+import selenium
 import undetected_chromedriver as uc
 from dateutil.relativedelta import relativedelta
+from packaging import version
 from selenium.common.exceptions import WebDriverException
 
 from ._config import DATA_DIR, LEAGUE_DICT, logger
@@ -403,7 +405,16 @@ class BaseSeleniumReader(BaseReader):
         # Start a new driver
         chrome_options = uc.ChromeOptions()
         if self.headless:
+            print("Starting ChromeDriver in headless mode.", selenium.__version__)
+            if version.parse(selenium.__version__) >= version.parse("4.13.0"):
+                raise ValueError(
+                    "Headless mode is not supported for Selenium 4.13.0 and above. "
+                    "Please downgrade to a lower version of Selenium or set "
+                    "'headless=False'."
+                )
             chrome_options.add_argument("--headless")
+        else:
+            chrome_options.headless = False
         if self.path_to_browser is not None:
             chrome_options.add_argument("--binary-location=" + str(self.path_to_browser))
         proxy = self.proxy()

--- a/soccerdata/whoscored.py
+++ b/soccerdata/whoscored.py
@@ -166,7 +166,7 @@ class WhoScored(BaseSeleniumReader):
         Path to the Chrome executable.
     headless : bool, default: True
         If True, will run Chrome in headless mode. Setting this to False might
-        help to avoid getting blocked.
+        help to avoid getting blocked. Only supported for Selenium <4.13.
     """
 
     def __init__(


### PR DESCRIPTION
Selenium does no longer support headless mode for version 4.13 and above. This was added to the docs and a warning is raised if headless mode is enabled for a recent version of Selenium.

Also adds a temporary fix for undetected-chromedriver, setting "headless" explicitly to False, such that soccerdata can still be used with recent versions of selenium.

Fixes #398