### PR TITLE
[WhoScored] Ignore cached events file if empty

### DIFF
--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -182,18 +182,15 @@ class BaseReader(ABC):
 
         return not cache_invalid and filepath is not None and filepath.exists()
 
-    def _size_file(
-        self,
-        filepath: Optional[Path] = None,
-        filter_size: int = 60
-    ) -> bool:
+    def _size_file(self, filepath: Optional[Path] = None, filter_size: int = 60) -> bool:
         """Check if `filepath` contains data valid size.
 
         Parameters
         ----------
         filepath : Path, optional
             Path where file should be cached. If None, return False.
-        filter_size : int file size threshold. If file is smaller, return False
+        filter_size : int
+            file size threshold. If file is smaller, return False
 
         Raises
         ------

--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -129,8 +129,7 @@ class BaseReader(ABC):
             File-like object of downloaded data.
         """
         is_cached = self._is_cached(filepath, max_age)
-        is_size = self._size_file(filepath)
-        if no_cache or self.no_cache or not is_cached or not is_size:
+        if no_cache or self.no_cache or not is_cached:
             logger.debug("Scraping %s", url)
             return self._download_and_save(url, filepath, var)
         logger.debug("Retrieving %s from cache", url)
@@ -181,36 +180,6 @@ class BaseReader(ABC):
                 cache_invalid = True
 
         return not cache_invalid and filepath is not None and filepath.exists()
-
-    def _size_file(self, filepath: Optional[Path] = None, filter_size: int = 60) -> bool:
-        """Check if `filepath` contains data valid size.
-
-        Parameters
-        ----------
-        filepath : Path, optional
-            Path where file should be cached. If None, return False.
-        filter_size : int
-            file size threshold. If file is smaller, return False
-
-        Raises
-        ------
-        TypeError
-            If filter_size is not an integer.
-
-        Returns
-        -------
-        bool
-            True in case of a cache hit, otherwise False.
-        """
-        if filepath is None:
-            return False
-        if not isinstance(filter_size, int):
-            raise TypeError("filter_size must be of type int")
-        try:
-            file_size = filepath.stat().st_size
-        except FileNotFoundError:
-            return False
-        return file_size > filter_size and filepath.exists()
 
     @abstractmethod
     def _download_and_save(

--- a/soccerdata/whoscored.py
+++ b/soccerdata/whoscored.py
@@ -703,6 +703,14 @@ class WhoScored(BaseSeleniumReader):
                 var="requirejs.s.contexts._.config.config.params.args.matchCentreData",
                 no_cache=live,
             )
+            if reader.read(4) == b'null':
+                reader = self.get(
+                    url,
+                    filepath,
+                    var="requirejs.s.contexts._.config.config.params.args.matchCentreData",
+                    no_cache=True,
+                )
+            reader.seek(0)
             json_data = json.load(reader)
             if json_data is not None:
                 player_names.update(


### PR DESCRIPTION
Hello, @probberechts.

I propose a solution to the problem of empty files in the cache for Whoscored.

In issue [98](https://github.com/probberechts/soccerdata/issues/98) you suggest delete empty file with bash command by file size.

I made method `_size_file` which does same with `Path.stat().st_size`. If the file is smaller than threshold, we believe that it is not cached

```python
    def _size_file(
        self,
        filepath: Optional[Path] = None,
        filter_size: int = 60
    ) -> bool:
        """Check if `filepath` contains data valid size.
        Parameters
        ----------
        filepath : Path, optional
            Path where file should be cached. If None, return False.
        filter_size : int file size threshold. If file is smaller, return False
        Raises
        ------
        TypeError
            If filter_size is not an integer.
        Returns
        -------
        bool
            True in case of a cache hit, otherwise False.
        """
        if filepath is None:
            return False
        if not isinstance(filter_size, int):
            raise TypeError("filter_size must be of type int")
        try:
            file_size = filepath.stat().st_size
        except FileNotFoundError:
            return False
        return file_size > filter_size and filepath.exists()
```