### PR TITLE
Add option to configure caching max-age via env

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -151,6 +151,9 @@ variables:
     default, data is retrieved from the cache.
 ``SOCCERDATA_NOSTORE``
     If set to "true", no data is stored. By default, data is cached.
+``SOCCERDATA_MAXAGE``
+    The maximum age of cached data in seconds. If the cached data is older
+    than this, it will be re-downloaded. By default, this is set to infinity.
 ``SOCCERDATA_LOGLEVEL``
     The level of logging to use. By default, this is set to "INFO".
 

--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -19,7 +19,7 @@ from dateutil.relativedelta import relativedelta
 from packaging import version
 from selenium.common.exceptions import WebDriverException
 
-from ._config import DATA_DIR, LEAGUE_DICT, logger
+from ._config import DATA_DIR, LEAGUE_DICT, MAXAGE, logger
 
 
 class BaseReader(ABC):
@@ -95,7 +95,7 @@ class BaseReader(ABC):
         self,
         url: str,
         filepath: Optional[Path] = None,
-        max_age: Optional[Union[int, timedelta]] = None,
+        max_age: Optional[Union[int, timedelta]] = MAXAGE,
         no_cache: bool = False,
         var: Optional[str] = None,
     ) -> IO[bytes]:
@@ -167,7 +167,7 @@ class BaseReader(ABC):
             elif isinstance(max_age, timedelta):
                 _max_age = max_age
             else:
-                raise TypeError("max_age must be of type int or datetime.timedelta")
+                raise TypeError("'max_age' must be of type int or datetime.timedelta")
         else:
             _max_age = None
 

--- a/soccerdata/_config.py
+++ b/soccerdata/_config.py
@@ -12,6 +12,9 @@ from rich.logging import RichHandler
 # Configuration
 NOCACHE = os.environ.get("SOCCERDATA_NOCACHE", 'False').lower() in ('true', '1', 't')
 NOSTORE = os.environ.get("SOCCERDATA_NOSTORE", 'False').lower() in ('true', '1', 't')
+MAXAGE = None
+if os.environ.get("SOCCERDATA_MAXAGE") is not None:
+    MAXAGE = int(os.environ.get("SOCCERDATA_MAXAGE", 0))
 LOGLEVEL = os.environ.get('SOCCERDATA_LOGLEVEL', 'INFO').upper()
 
 # Directories


### PR DESCRIPTION
This commit adds a "SOCCERDATA_MAXAGE" environment variable. If set, cached data that is older than the configured max-age will be re-downloaded. This is useful for testing. We want to check regularly whether the scrapers can still parse the remote data, but downloading all data in each test run is too slow.