### PR TITLE
Rename FIFA --> EA Sports FC

### DIFF
--- a/docs/datasources/index.rst
+++ b/docs/datasources/index.rst
@@ -88,7 +88,7 @@ SoFIFA
 
       from soccerdata import SoFIFA
 
-    Detailed scores on all player's abilities from EA Sports FIFA.
+    Detailed scores on all player's abilities from EA Sports FC.
 
 -----
 


### PR DESCRIPTION
I changed "Detailed scores on all player's abilities from EA Sports FIFA." to "Detailed scores on all player's abilities from EA Sports FC." as the name of the game changed in September 2023.