### PR TITLE
[WhoScored] Add options to skip/retry/raise when scraping match events fails

### DIFF
--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -467,8 +467,12 @@ class BaseSeleniumReader(BaseReader):
                 return io.BytesIO(response)
             except Exception:
                 logger.exception(
-                    "Error while scraping %s. Retrying... (attempt %d of 5).", url, i + 1
+                    "Error while scraping %s. Retrying in %d seconds... (attempt %d of 5).",
+                    url,
+                    i * 10,
+                    i + 1,
                 )
+                time.sleep(i * 10)
                 self._driver = self._init_webdriver()
                 continue
 

--- a/soccerdata/whoscored.py
+++ b/soccerdata/whoscored.py
@@ -693,7 +693,7 @@ class WhoScored(BaseSeleniumReader):
             If the requested output format is 'spadl', 'atomic-spadl' or
             'loader' but the socceraction package is not installed.
         Exception
-            If the match page could be be retrieved.
+            If the match page could not be retrieved.
 
         Returns
         -------


### PR DESCRIPTION
- Adds a "retry_missing" option to the read_events method to control whether to retry or skip games for which no events are available.
- Adds a "skip_on_error" option to the read_events method to control whether to raise an exception or skip the match when the match page cannot be retrieved.