### PR TITLE
[WhoScored] Error handling for missing events

### DIFF
--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -20,7 +20,7 @@ import selenium
 import undetected_chromedriver as uc
 from dateutil.relativedelta import relativedelta
 from packaging import version
-from selenium.common.exceptions import WebDriverException
+from selenium.common.exceptions import WebDriverException, JavascriptException
 
 from ._config import DATA_DIR, LEAGUE_DICT, MAXAGE, logger
 
@@ -643,9 +643,12 @@ class BaseSeleniumReader(BaseReader):
                 else:
                     if not isinstance(var, str):
                         raise NotImplementedError("Only implemented for single variables.")
-                    response = json.dumps(self._driver.execute_script("return " + var)).encode(
-                        "utf-8"
-                    )
+                    try:
+                        response = json.dumps(self._driver.execute_script("return " + var)).encode(
+                            "utf-8"
+                        )
+                    except JavascriptException:
+                        response = json.dumps(None).encode("utf-8")
                 if not self.no_store and filepath is not None:
                     filepath.parent.mkdir(parents=True, exist_ok=True)
                     with filepath.open(mode="wb") as fh:

--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -20,7 +20,7 @@ import selenium
 import undetected_chromedriver as uc
 from dateutil.relativedelta import relativedelta
 from packaging import version
-from selenium.common.exceptions import WebDriverException, JavascriptException
+from selenium.common.exceptions import JavascriptException, WebDriverException
 
 from ._config import DATA_DIR, LEAGUE_DICT, MAXAGE, logger
 

--- a/soccerdata/whoscored.py
+++ b/soccerdata/whoscored.py
@@ -706,7 +706,7 @@ class WhoScored(BaseSeleniumReader):
                     var="require.config.params['args'].matchCentreData",
                     no_cache=live,
                 )
-                if retry_missing and reader.read(4) == b"null":
+                if retry_missing and reader.read() == b"null" or reader.read() == b"":
                     reader = self.get(
                         url,
                         filepath,
@@ -779,6 +779,9 @@ class WhoScored(BaseSeleniumReader):
                 },
             )
 
+        if len(events) == 0:
+            return pd.DataFrame(index=["league", "season", "game"])
+
         df = (
             pd.concat(events.values())
             .pipe(standardize_colnames)
@@ -789,7 +792,7 @@ class WhoScored(BaseSeleniumReader):
         )
 
         if output_fmt == "events":
-            df = df.set_index(["league", "season", "game", "id"]).sort_index()
+            df = df.set_index(["league", "season", "game"]).sort_index()
             # add missing columns
             for col, default in COLS_EVENTS.items():
                 if col not in df.columns:

--- a/soccerdata/whoscored.py
+++ b/soccerdata/whoscored.py
@@ -706,7 +706,8 @@ class WhoScored(BaseSeleniumReader):
                     var="require.config.params['args'].matchCentreData",
                     no_cache=live,
                 )
-                if retry_missing and reader.read() == b"null" or reader.read() == b"":
+                reader_value = reader.read()
+                if retry_missing and reader_value == b"null" or reader_value == b"":
                     reader = self.get(
                         url,
                         filepath,


### PR DESCRIPTION
Previously, the javascript variable that stores all events was empty when no events were available for a given game. Since the change fixed in #618, the javascript variable is missing instead, resulting in a `JavascriptException`. This commit updates the error handling accordingly.

Closes #633