### PR TITLE
[Fotmob] Include matches which ended in extra time or after penalties 

### DIFF
--- a/soccerdata/fotmob.py
+++ b/soccerdata/fotmob.py
@@ -362,7 +362,7 @@ class FotMob(BaseRequestsReader):
 
         # Retrieve games for which a match report is available
         df_matches = self.read_schedule(force_cache)
-        df_complete = df_matches.loc[df_matches["status"] == "FT"]
+        df_complete = df_matches.loc[df_matches["status"].isin(["FT", "AET", "Pen"])]
 
         if team is not None:
             # get alternative names of the specified team(s)


### PR DESCRIPTION
Currently only games which were concluded in standard time are returned from read_match_stats as the status code for games that were decided in extra time or by penalties do not have the "FT" status.

I am re-raising this PR as the previous PR failed on the codecov check as it wasn't enabled on my repository when I made the PR, and I could not see how to trigger another check, and would rather just re-raise the PR than push a dummy commit.