### PR TITLE
[FBref] Update rate limit to 10 requests/sec

### DIFF
--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -82,7 +82,7 @@ class FBref(BaseRequestsReader):
             no_store=no_store,
             data_dir=data_dir,
         )
-        self.rate_limit = 3
+        self.rate_limit = 6
         self.seasons = seasons  # type: ignore
         # check if all top 5 leagues are selected
         if (


### PR DESCRIPTION
FBref has increased rate limiting from twenty to ten requests per minute. See <https://www.sports-reference.com/bot-traffic.html>.

Fixes #668