### PR TITLE
feat(sofascore): support 2nd tier leagues

### DIFF
--- a/soccerdata/sofascore.py
+++ b/soccerdata/sofascore.py
@@ -86,7 +86,7 @@ class Sofascore(BaseRequestsReader):
         -------
         pd.DataFrame
         """
-        url = SOFASCORE_API + "config/top-unique-tournaments/EN/football"
+        url = SOFASCORE_API + "config/unique-tournaments/EN/football"
         filepath = self.data_dir / "leagues.json"
         reader = self.get(url, filepath)
         data = json.load(reader)


### PR DESCRIPTION
Adds support for adding custom leagues that are not one of the 'top-tournaments'.

Fixes #679