### PR TITLE
Fix missing coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 name: CI
-
 on:
   - push
   - pull_request
-
 jobs:
   tests:
     name: ${{ matrix.session }} ${{ matrix.python }} / ${{ matrix.os }}
@@ -12,24 +10,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { python: "3.11", os: "ubuntu-latest", session: "pre-commit" }
-          - { python: "3.11", os: "ubuntu-latest", session: "mypy" }
-          - { python: "3.11", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.10", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.9", os: "ubuntu-latest", session: "tests" }
-          - { python: "3.11", os: "windows-latest", session: "tests" }
-          - { python: "3.11", os: "macos-latest", session: "tests" }
-          - { python: "3.11", os: "ubuntu-latest", session: "docs-build" }
-
+          - {python: "3.11", os: "ubuntu-latest", session: "pre-commit"}
+          - {python: "3.11", os: "ubuntu-latest", session: "mypy"}
+          - {python: "3.11", os: "ubuntu-latest", session: "tests"}
+          - {python: "3.10", os: "ubuntu-latest", session: "tests"}
+          - {python: "3.9", os: "ubuntu-latest", session: "tests"}
+          - {python: "3.11", os: "windows-latest", session: "tests"}
+          - {python: "3.11", os: "macos-latest", session: "tests"}
+          - {python: "3.11", os: "ubuntu-latest", session: "docs-build"}
     env:
       NOXSESSION: ${{ matrix.session }}
       FORCE_COLOR: "1"
       PRE_COMMIT_COLOR: "always"
-
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4.1.7
-
       - name: Restore data cache
         if: matrix.session == 'tests'
         id: cache-data
@@ -37,17 +32,14 @@ jobs:
         with:
           path: tests/appdata/data
           key: cache-data-${{ runner.os }}-${{ matrix.python }}
-
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v5.2.0
         with:
           python-version: ${{ matrix.python }}
-
       - name: Upgrade pip
         run: |
           pip install --constraint=.github/workflows/constraints.txt pip
           pip --version
-
       - name: Upgrade pip in virtual environments
         shell: python
         run: |
@@ -56,18 +48,15 @@ jobs:
 
           with open(os.environ["GITHUB_ENV"], mode="a") as io:
               print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
-
       - name: Install Poetry
         run: |
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt poetry
           poetry --version
-
       - name: Install Nox
         run: |
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
           pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry
           nox --version
-
       - name: Compute pre-commit cache key
         if: matrix.session == 'pre-commit'
         id: pre-commit-cache
@@ -82,7 +71,6 @@ jobs:
           result = "${{ runner.os }}-{}-{}-pre-commit".format(python, digest[:8])
 
           print("::set-output name=result::{}".format(result))
-
       - name: Restore pre-commit cache
         uses: actions/cache@v4.0.2
         if: matrix.session == 'pre-commit'
@@ -91,70 +79,58 @@ jobs:
           key: ${{ steps.pre-commit-cache.outputs.result }}-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             ${{ steps.pre-commit-cache.outputs.result }}-
-
       - name: Install pandoc
         if: matrix.session == 'docs-build'
         run: sudo apt-get install -y pandoc
-
       - name: Run Nox
         run: |
           nox --force-color --python=${{ matrix.python }}
-
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-data-${{ matrix.os }}-${{ matrix.python }}
           path: ".coverage.*"
-
+          include-hidden-files: true
       - name: Upload documentation
         if: matrix.session == 'docs-build'
         uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/_build
-
   coverage:
     runs-on: ubuntu-latest
     needs: tests
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4.1.7
-
       - name: Set up Python
         uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.11"
-
       - name: Upgrade pip
         run: |
           pip install --constraint=.github/workflows/constraints.txt pip
           pip --version
-
       - name: Install Poetry
         run: |
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt poetry
           poetry --version
-
       - name: Install Nox
         run: |
           pipx install --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox
           pipx inject --pip-args=--constraint=${{ github.workspace }}/.github/workflows/constraints.txt nox nox-poetry
           nox --version
-
       - name: Download coverage data
         uses: actions/download-artifact@v4
         with:
           pattern: coverage-data-*
           merge-multiple: true
-
       - name: Combine coverage data and display human readable report
         run: |
           nox --force-color --session=coverage
-
       - name: Create coverage report
         run: |
           nox --force-color --session=coverage -- xml
-
       - name: Upload coverage report
         uses: codecov/codecov-action@v4.5.0


### PR DESCRIPTION
From September 2nd, 2024, the GitHub action update-artifact does not upload hidden files and folders by default. This caused trouble with .coverage files.