### PR TITLE
Feature to extract players URL in FBREF

### DIFF
--- a/tests/test_FBref.py
+++ b/tests/test_FBref.py
@@ -92,6 +92,10 @@ def test_read_player_season_stats(fbref_ligue1: FBref, stat_type: str) -> None:
     assert isinstance(fbref_ligue1.read_player_season_stats(stat_type), pd.DataFrame)
 
 
+def test_read_player_season_stats_with_player_url(fbref_ligue1: FBref) -> None:
+    assert isinstance(fbref_ligue1.read_player_season_stats("standard", True), pd.DataFrame)
+
+
 def test_read_schedule(fbref_ligue1: FBref) -> None:
     assert isinstance(fbref_ligue1.read_schedule(), pd.DataFrame)
 
@@ -110,7 +114,8 @@ def test_read_schedule(fbref_ligue1: FBref) -> None:
 )
 def test_read_player_match_stats(fbref_ligue1: FBref, stat_type: str) -> None:
     assert isinstance(
-        fbref_ligue1.read_player_match_stats(stat_type, match_id="796787da"), pd.DataFrame
+        fbref_ligue1.read_player_match_stats(stat_type, match_id="796787da"),
+        pd.DataFrame,
     )
 
 
@@ -143,17 +148,29 @@ def test_read_lineup(fbref_ligue1: FBref) -> None:
 def test_concat() -> None:
     df1 = pd.DataFrame(
         columns=pd.MultiIndex.from_tuples(
-            [("Unnamed: a", "player"), ("Performance", "Goals"), ("Performance", "Assists")]
+            [
+                ("Unnamed: a", "player"),
+                ("Performance", "Goals"),
+                ("Performance", "Assists"),
+            ]
         )
     )
     df2 = pd.DataFrame(
         columns=pd.MultiIndex.from_tuples(
-            [("Unnamed: a", "player"), ("Unnamed: b", "Goals"), ("Performance", "Assists")]
+            [
+                ("Unnamed: a", "player"),
+                ("Unnamed: b", "Goals"),
+                ("Performance", "Assists"),
+            ]
         )
     )
     df3 = pd.DataFrame(
         columns=pd.MultiIndex.from_tuples(
-            [("Unnamed: a", "player"), ("Goals", "Unnamed: b"), ("Performance", "Assists")]
+            [
+                ("Unnamed: a", "player"),
+                ("Goals", "Unnamed: b"),
+                ("Performance", "Assists"),
+            ]
         )
     )
     res = _concat([df1, df2, df3], key=["player"])


### PR DESCRIPTION
This PR adds an option in the `read_player_season_stats` method. When extracting player statistics, it may be interesting to get the URL to the player page as well. This way, we can get additional information in our application with a simple scraping on the player page (for instance, the player picture).