### PR TITLE
fix(SoFIFA): fix iteration indent error in read_player_ratings

### DIFF
--- a/soccerdata/sofifa.py
+++ b/soccerdata/sofifa.py
@@ -476,21 +476,21 @@ class SoFIFA(BaseRequestsReader):
                 **version.to_dict(),
             }
 
-        # Try each XPath until one returns a result
-        for s in score_labels:
-            value = None
-            xpaths = [
-                f"//p[.//text()[contains(.,'{s}')]]/span/em",
-                f"//div[contains(.,'{s}')]/em",
-                f"//li[not(self::script)][.//text()[contains(.,'{s}')]]/em",
-            ]
-            for xpath in xpaths:
-                nodes = tree.xpath(xpath)
-                if nodes:  # If at least one match is found
-                    value = nodes[0].text.strip()  # Take only the first match
-                    break  # Stop checking other XPaths once we find a valid value
+            # Try each XPath until one returns a result
+            for s in score_labels:
+                value = None
+                xpaths = [
+                    f"//p[.//text()[contains(.,'{s}')]]/span/em",
+                    f"//div[contains(.,'{s}')]/em",
+                    f"//li[not(self::script)][.//text()[contains(.,'{s}')]]/em",
+                ]
+                for xpath in xpaths:
+                    nodes = tree.xpath(xpath)
+                    if nodes:  # If at least one match is found
+                        value = nodes[0].text.strip()  # Take only the first match
+                        break  # Stop checking other XPaths once we find a valid value
 
-            scores[s] = value if value is not None else None  # Assign only once
-        ratings.append(scores)
+                scores[s] = value if value is not None else None  # Assign only once
+            ratings.append(scores)
         # return data frame
         return pd.DataFrame(ratings).pipe(standardize_colnames).set_index(["player"]).sort_index()


### PR DESCRIPTION
Fix iteration indent error in `SoFIFA.read_player_ratings`

- Test code:
![image](https://github.com/user-attachments/assets/7660d007-3bae-472e-a7ea-47d346d8c007)

- Before fixing: method `read_player_ratings` would return only one line information
![image](https://github.com/user-attachments/assets/0285a901-b383-4465-a8e8-6cb6312880de)

- After fixing: 
![image](https://github.com/user-attachments/assets/77e40969-9800-47db-bdcb-f4f5e114fe42)
