### PR TITLE
[FotMob] Added support for retrieving "Expected goals on target (xGOT)" stats

### DIFF
--- a/soccerdata/fotmob.py
+++ b/soccerdata/fotmob.py
@@ -340,6 +340,7 @@ class FotMob(BaseRequestsReader):
             * 'Top stats'
             * 'Shots'
             * 'Expected goals (xG)'
+            * 'Expected goals on target (xGOT)'
             * 'Passes'
             * 'Defence'
             * 'Duels'
@@ -410,12 +411,25 @@ class FotMob(BaseRequestsReader):
 
             # Get stats types
             all_stats = game_data["content"]["stats"]["Periods"]["All"]["stats"]
+
+            # create an alias for nested stats
+            alias_map = {
+                "Expected goals on target (xGOT)": "Expected goals (xG)",
+            }
+            parent_type = alias_map.get(stat_type, stat_type)
+
             try:
-                selected_stats = next(stat for stat in all_stats if stat["title"] == stat_type)
+                selected_stats = next(stat for stat in all_stats if stat["title"] == parent_type)
             except StopIteration:
                 raise ValueError(f"Invalid stat type: {stat_type}")
 
             df_raw_stats = pd.DataFrame(selected_stats["stats"])
+
+            # xGOT filter
+            if stat_type == "Expected goals on target (xGOT)":
+                title_filter = "Expected goals on target (xGOT)"
+                df_raw_stats = df_raw_stats[df_raw_stats["title"] == title_filter]
+
             game_teams = [game.home_team, game.away_team]
             for i, team in enumerate(game_teams):
                 df_team_stats = df_raw_stats.copy()

--- a/tests/test_FotMob.py
+++ b/tests/test_FotMob.py
@@ -22,7 +22,7 @@ def test_read_schedule(fotmob_laliga: FotMob) -> None:
 @pytest.mark.fails_gha()
 @pytest.mark.parametrize(
     "stat_type",
-    ["Top stats", "Shots", "Expected goals (xG)", "Passes", "Defence", "Duels", "Discipline"],
+    ["Top stats", "Shots", "Expected goals (xG)", "Expected goals on target (xGOT)", "Passes", "Defence", "Duels", "Discipline"],
 )
 def test_read_team_match_stats(fotmob_laliga: FotMob, stat_type: str) -> None:
     assert isinstance(


### PR DESCRIPTION
### Changes Made

- Enhanced `read_team_match_stats` to recognize and extract the `"xG on target (xGOT)"` field from within the `"Expected goals (xG)"` section.
- Updated the test suite (`test_read_team_match_stats`) to include `stat_type="Expected goals on target (xGOT)"`.

Closes #781 — This feature allows users to explicitly request xGOT data, which was previously included in the data but not directly accessible.


