### PR TITLE
[Sofascore] Bypass TLS fingerprinting

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -356,22 +356,6 @@ files = [
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
-name = "cloudscraper"
-version = "1.2.71"
-description = "A Python module to bypass Cloudflare's anti-bot page."
-optional = false
-python-versions = "*"
-files = [
-    {file = "cloudscraper-1.2.71-py2.py3-none-any.whl", hash = "sha256:76f50ca529ed2279e220837befdec892626f9511708e200d48d5bb76ded679b0"},
-    {file = "cloudscraper-1.2.71.tar.gz", hash = "sha256:429c6e8aa6916d5bad5c8a5eac50f3ea53c9ac22616f6cb21b18dcc71517d0d3"},
-]
-
-[package.dependencies]
-pyparsing = ">=2.4.7"
-requests = ">=2.9.2"
-requests-toolbelt = ">=0.9.1"
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -1656,20 +1640,6 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
-name = "pyparsing"
-version = "3.1.2"
-description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-optional = false
-python-versions = ">=3.6.8"
-files = [
-    {file = "pyparsing-3.1.2-py3-none-any.whl", hash = "sha256:f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742"},
-    {file = "pyparsing-3.1.2.tar.gz", hash = "sha256:a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad"},
-]
-
-[package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
-
-[[package]]
 name = "pysocks"
 version = "1.7.1"
 description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
@@ -2000,20 +1970,6 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
-
-[[package]]
-name = "requests-toolbelt"
-version = "1.0.0"
-description = "A utility belt for advanced users of python-requests"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6"},
-    {file = "requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06"},
-]
-
-[package.dependencies]
-requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "rich"
@@ -2751,6 +2707,27 @@ files = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.67.1"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
+    {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
+discord = ["requests"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "traitlets"
 version = "5.14.3"
 description = "Traitlets Python configuration system"
@@ -3175,6 +3152,17 @@ files = [
 ]
 
 [[package]]
+name = "wrapper-tls-requests"
+version = "1.1.4"
+description = "A powerful and lightweight Python library for making secure and reliable HTTP/TLS Fingerprint requests."
+optional = false
+python-versions = "*"
+files = [
+    {file = "wrapper_tls_requests-1.1.4-py3-none-any.whl", hash = "sha256:01d6dddb8689d3bb289826f291fffd15cdba8995fcbeddb1935e1567d02e7f90"},
+    {file = "wrapper_tls_requests-1.1.4.tar.gz", hash = "sha256:af62b25f4ad2c7506f07675e2857d1ffb407be1f6c913291650dd69c594797d3"},
+]
+
+[[package]]
 name = "wrapt"
 version = "1.16.0"
 description = "Module for decorators, wrappers and monkey patching."
@@ -3288,4 +3276,4 @@ socceraction = ["socceraction"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "1f28bc90cc5146bfc8f44674cb80736bb7b47476dccf78aa8c4a0877b27eee14"
+content-hash = "94de5e5b3e5b832e99e0cf6a475f17e391fc226f18fbb252c723e3f16950f4a8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ Changelog = "https://github.com/probberechts/soccerdata/releases"
 python = ">=3.9,<3.13"
 PySocks = "^1.7.1"
 Unidecode = "^1.2.0"
-cloudscraper = "^1.2.71"
 html5lib = "^1.1"
 pandas = "^2.0.0, !=2.1.0"
 requests = "^2.23"
@@ -32,6 +31,8 @@ unicode = "^2.7"
 lxml = "^4.9.3"
 socceraction = {version="^1.5.3", optional=true}
 packaging = "^24.1"
+wrapper-tls-requests = "^1.1.4"
+tqdm = "^4.67.1"
 
 [tool.poetry.extras]
 socceraction = ["socceraction"]

--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -523,7 +523,7 @@ class BaseRequestsReader(BaseReader):
         """Download file at url to filepath. Overwrites if filepath exists."""
         for i in range(5):
             try:
-                response = self._session.get(url, stream=True)
+                response = self._session.get(url)
                 time.sleep(self.rate_limit + random.random() * self.max_delay)
                 response.raise_for_status()
                 if var is not None:

--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -223,7 +223,7 @@ class BaseReader(ABC):
         self,
         leagues: Optional[Union[str, list[str]]] = None,
         proxy: Optional[
-            Union[str, dict[str, str], list[dict[str, str]], Callable[[], dict[str, str]]]
+            Union[str, list[str], Callable[[], str]]
         ] = None,
         no_cache: bool = False,
         no_store: bool = False,

--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -511,8 +511,7 @@ class BaseRequestsReader(BaseReader):
             if protocol in proxy:
                 proxy_url = proxy[protocol]
                 break
-        session = tls_requests.Client(proxy=proxy_url)
-        return session
+        return tls_requests.Client(proxy=proxy_url)
 
     def _download_and_save(
         self,

--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -239,7 +239,7 @@ class BaseReader(ABC):
         elif callable(proxy):
             self.proxy = proxy
         else:
-            self.proxy = lambda : None
+            self.proxy = lambda: None
 
         self._selected_leagues = leagues  # type: ignore
         self.no_cache = no_cache
@@ -495,8 +495,7 @@ class BaseRequestsReader(BaseReader):
         self._session = self._init_session()
 
     def _init_session(self) -> tls_requests.Client:
-        session = tls_requests.Client(proxy=self.proxy())
-        return session
+        return tls_requests.Client(proxy=self.proxy())
 
     def _download_and_save(
         self,

--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -222,9 +222,7 @@ class BaseReader(ABC):
     def __init__(
         self,
         leagues: Optional[Union[str, list[str]]] = None,
-        proxy: Optional[
-            Union[str, list[str], Callable[[], str]]
-        ] = None,
+        proxy: Optional[Union[str, list[str], Callable[[], str]]] = None,
         no_cache: bool = False,
         no_store: bool = False,
         data_dir: Path = DATA_DIR,


### PR DESCRIPTION
Sofascore now uses TLS fingerprinting to detect bots. This PR uses the `tls-requests` to bypass TLS Fingerprinting.