### PR TITLE
add ability spadl and atomic spadl format in no_store == True mode.

### DIFF
--- a/soccerdata/whoscored.py
+++ b/soccerdata/whoscored.py
@@ -738,7 +738,7 @@ class WhoScored(BaseSeleniumReader):
                         events[game["game_id"]] = game_events
                     elif output_fmt in ["spadl", "atomic-spadl"]:
                         parser = WhoScoredParser(
-                            json_data if self.no_store == True else str(filepath),
+                            json_data if self.no_store else str(filepath),
                             competition_id=game["league"],
                             season_id=game["season"],
                             game_id=game["game_id"],


### PR DESCRIPTION
Hello, @probberechts.

This PR allows you to work with spadl and atomic spadl formats in the mode without saving to disk (no_store == True).

There is a blocker for this PR: my PR to socceraction library to change the behavior of the WhoScoredParser class. It must be accepted for this PR to make sense.

PR in socceraction library:
https://github.com/ML-KULeuven/socceraction/pull/948