### PR TITLE
[FotMob] Update read_schedule to use "fixtures" key

### DIFF
--- a/soccerdata/fotmob.py
+++ b/soccerdata/fotmob.py
@@ -286,7 +286,7 @@ class FotMob(BaseRequestsReader):
             reader = self.get(url, filepath, no_cache=current_season and not force_cache)
             season_data = json.load(reader)
 
-            df = pd.json_normalize(season_data["matches"]["allMatches"])
+            df = pd.json_normalize(season_data["fixtures"]["allMatches"])
             df["league"] = lkey
             df["season"] = skey
             all_schedules.append(df)


### PR DESCRIPTION
FotMob appears to have changed the JSON key from "matches" to "fixtures" for this function, causing read_schedule to fail for FotMob. 