### PR TITLE
[FBref] Add "sec-ch-ua" header

### DIFF
--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -476,6 +476,7 @@ class BaseRequestsReader(BaseReader):
         no_cache: bool = False,
         no_store: bool = False,
         data_dir: Path = DATA_DIR,
+        headers: Optional[dict[str, str]] = None,
     ):
         """Initialize the reader."""
         super().__init__(
@@ -486,10 +487,10 @@ class BaseRequestsReader(BaseReader):
             data_dir=data_dir,
         )
 
-        self._session = self._init_session()
+        self._session = self._init_session(headers)
 
-    def _init_session(self) -> tls_requests.Client:
-        return tls_requests.Client(proxy=self.proxy())
+    def _init_session(self, headers: Optional[dict[str, str]] = None) -> tls_requests.Client:
+        return tls_requests.Client(proxy=self.proxy(), headers=headers)
 
     def _download_and_save(
         self,

--- a/soccerdata/fbref.py
+++ b/soccerdata/fbref.py
@@ -20,6 +20,9 @@ from ._config import DATA_DIR, NOCACHE, NOSTORE, TEAMNAME_REPLACEMENTS, logger
 
 FBREF_DATADIR = DATA_DIR / "FBref"
 FBREF_API = "https://fbref.com"
+FBREF_HEADERS = {
+    "sec-ch-ua": '"Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"',
+}
 
 BIG_FIVE_DICT = {
     "Serie A": "ITA-Serie A",
@@ -78,6 +81,7 @@ class FBref(BaseRequestsReader):
             no_cache=no_cache,
             no_store=no_store,
             data_dir=data_dir,
+            headers=FBREF_HEADERS,
         )
         self.rate_limit = 7
         self.seasons = seasons


### PR DESCRIPTION
FBref now checks for the Sec-CH-UA request header. If this header is not present, it returns a "403 Forbidden" error.

Fixes #879