### PR TITLE
[Sofascore] Update tournaments URL

### DIFF
--- a/soccerdata/sofascore.py
+++ b/soccerdata/sofascore.py
@@ -77,7 +77,7 @@ class Sofascore(BaseRequestsReader):
         -------
         pd.DataFrame
         """
-        url = SOFASCORE_API + "config/unique-tournaments/EN/football"
+        url = SOFASCORE_API + "config/default-unique-tournaments/EN/football"
         filepath = self.data_dir / "leagues.json"
         reader = self.get(url, filepath)
         data = json.load(reader)


### PR DESCRIPTION
The API address for fetching the list of tournaments changed from "https://www.sofascore.com/api/v1/config/unique-tournaments/EN/football" to "https://www.sofascore.com/api/v1/config/default-unique-tournaments/EN/football"