### PR TITLE
[Whoscored] Unwrap JSON wrapped in HTML <pre> from page_source

### DIFF
--- a/soccerdata/whoscored.py
+++ b/soccerdata/whoscored.py
@@ -842,4 +842,17 @@ class WhoScored(BaseSeleniumReader):
             )
         if not page_html:
             raise Exception("Empty response.")
+        # Browsers render JSON responses as <pre> inside HTML; unwrap so callers
+        # that json.load() the response keep working.
+        stripped = page_html.lstrip()
+        if stripped.startswith("<"):
+            try:
+                tree = html.fromstring(page_html)
+            except Exception:
+                return page_html
+            pre = tree.xpath("//pre")
+            if pre and pre[0].text:
+                text = pre[0].text.strip()
+                if text and text[0] in "{[":
+                    return text
         return page_html

--- a/tests/test_Whoscored.py
+++ b/tests/test_Whoscored.py
@@ -1,6 +1,10 @@
 """Unittests for class soccerdata.WhoScored."""
 
+from unittest.mock import MagicMock
+
 import pandas as pd
+
+from soccerdata.whoscored import WhoScored
 
 # Unittests -------------------------------------------------------------------
 
@@ -11,3 +15,19 @@ def test_whoscored_missing_players(whoscored):
 
 def test_whoscored_events(whoscored):
     assert isinstance(whoscored.read_events(1485184), pd.DataFrame)
+
+
+def test_validate_page_unwraps_json_in_pre():
+    instance = WhoScored.__new__(WhoScored)
+    driver = MagicMock()
+    driver.page_source = '<html><body><pre>{"tournaments": []}</pre></body></html>'
+    instance._driver = driver
+    assert instance._validate_page("http://example") == '{"tournaments": []}'
+
+
+def test_validate_page_passes_through_html():
+    instance = WhoScored.__new__(WhoScored)
+    driver = MagicMock()
+    driver.page_source = "<html><body><h1>hi</h1></body></html>"
+    instance._driver = driver
+    assert instance._validate_page("http://example") == driver.page_source


### PR DESCRIPTION
Fixes #940.

`WhoScored.read_schedule` and other endpoints call `json.load` on the response returned by `get(..., var=None)`. In 1.9.0 the response is the page source returned by Selenium, which browsers render as `<html><body><pre>{...}</pre></body></html>` for raw JSON URLs. `json.load` then raises `JSONDecodeError`.

Override `_validate_page` on `WhoScored` to detect that wrapper and return the underlying JSON text, with a fallthrough that preserves the existing HTML path.