### PR TITLE
fix(whoscored): unwrap JSON rendered as bare <body> text without <pre>

### DIFF
--- a/soccerdata/whoscored.py
+++ b/soccerdata/whoscored.py
@@ -855,4 +855,11 @@ class WhoScored(BaseSeleniumReader):
                 text = pre[0].text.strip()
                 if text and text[0] in "{[":
                     return text
+            # Some browser/driver combinations render JSON responses as bare
+            # <body> text without a <pre> element (see #940).
+            body = tree.xpath("//body")
+            if body:
+                text = body[0].text_content().strip()
+                if text and text[0] in "{[":
+                    return text
         return page_html

--- a/tests/test_Whoscored.py
+++ b/tests/test_Whoscored.py
@@ -25,6 +25,22 @@ def test_validate_page_unwraps_json_in_pre():
     assert instance._validate_page("http://example") == '{"tournaments": []}'
 
 
+def test_validate_page_unwraps_json_in_body_without_pre():
+    instance = WhoScored.__new__(WhoScored)
+    driver = MagicMock()
+    driver.page_source = '<html><head></head><body>{"tournaments": []}</body></html>'
+    instance._driver = driver
+    assert instance._validate_page("http://example") == '{"tournaments": []}'
+
+
+def test_validate_page_unwraps_json_in_body_with_whitespace():
+    instance = WhoScored.__new__(WhoScored)
+    driver = MagicMock()
+    driver.page_source = '<html><head></head><body>\n {"tournaments": []}\n</body></html>'
+    instance._driver = driver
+    assert instance._validate_page("http://example") == '{"tournaments": []}'
+
+
 def test_validate_page_passes_through_html():
     instance = WhoScored.__new__(WhoScored)
     driver = MagicMock()


### PR DESCRIPTION
Follow-up to #944, which fixed #940 by unwrapping JSON from a `<pre>` element.

On my machine (Chrome 141, seleniumbase uc mode) the fixtures feeds come back as `<html><head></head><body>{...}</body></html>` with no `<pre>` at all. `read_schedule()` then still fails with the same JSONDecodeError as in #940 and the wrapped HTML gets written into the cache file.

This adds a fallback in `_validate_page`: when there is no usable `<pre>`, take the `<body>` text and return it if it looks like JSON. Plain HTML pages still pass through unchanged.

Verified live against GER-Bundesliga 2526: `read_schedule()` returns 306 games and `read_events()` parses a full match afterwards. Both wrapper variants are covered by unit tests next to the existing ones.

Refs #940