### PR TITLE
docs: add instructions to install dependencies using uv

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -95,12 +95,15 @@ Information about installation options and instructions for Windows can be found
 `uv's installation guide <https://docs.astral.sh/uv/getting-started/installation/>`_.
 
 Next, create and activate a virtual environment using uv with a Python version
-that soccerdata supports:
+that soccerdata supports, and install the required dependencies in the 
+virtual environment:
 
 .. code:: console
 
     $ uv venv --python 3.10
     $ source .venv/bin/activate
+    $ uv pip install -r requirements.txt
+    $ uv pip install -e 
 
 Alternatively, you can use `pip`. You'll need to have at least the minimum
 Python version that soccerdata supports. Next, install the required

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,8 +102,8 @@ virtual environment:
 
     $ uv venv --python 3.10
     $ source .venv/bin/activate
+    $ uv pip install -e .
     $ uv pip install -r requirements.txt
-    $ uv pip install -e 
 
 Alternatively, you can use `pip`. You'll need to have at least the minimum
 Python version that soccerdata supports. Next, install the required

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -101,9 +101,7 @@ virtual environment:
 .. code:: console
 
     $ uv venv --python 3.10
-    $ source .venv/bin/activate
-    $ uv pip install -e .
-    $ uv pip install -r requirements.txt
+    $ uv sync
 
 Alternatively, you can use `pip`. You'll need to have at least the minimum
 Python version that soccerdata supports. Next, install the required


### PR DESCRIPTION
The CONTRIBUTING.rst file doesn't explicitly state how to install the dependencies in the virtual environment, using the uv tool. This adds the relevant lines into the docs.

Before:
<img width="1037" height="128" alt="Screenshot 2026-07-13 at 13 10 58" src="https://github.com/user-attachments/assets/d61705c7-f4f9-4d06-b35c-810bac8c4d3a" />


After:
<img width="1064" height="190" alt="Screenshot 2026-07-13 at 13 15 23" src="https://github.com/user-attachments/assets/7da31947-e949-4ef8-a64b-c27ce263c4da" />





