### PR TITLE
fix: preserve WhoScored event IDs in formatted output

### DIFF
--- a/soccerdata/whoscored.py
+++ b/soccerdata/whoscored.py
@@ -27,6 +27,8 @@ WHOSCORED_URL = "https://www.whoscored.com"
 COLS_EVENTS = {
     # The ID of the game
     "game_id": np.nan,
+    # The ID of the event
+    "event_id": np.nan,
     # 'PreMatch', 'FirstHalf', 'SecondHalf', 'PostGame'
     "period": np.nan,
     # Integer indicating the minute of the event, ignoring stoppage time

--- a/tests/test_Whoscored.py
+++ b/tests/test_Whoscored.py
@@ -1,5 +1,8 @@
 """Unittests for class soccerdata.WhoScored."""
 
+import io
+import json
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -15,6 +18,46 @@ def test_whoscored_missing_players(whoscored):
 
 def test_whoscored_events(whoscored):
     assert isinstance(whoscored.read_events(1485184), pd.DataFrame)
+
+
+def test_whoscored_events_preserve_event_id():
+    instance = WhoScored.__new__(WhoScored)
+    instance.data_dir = Path(".")
+    instance.read_schedule = MagicMock(
+        return_value=pd.DataFrame(
+            [
+                {
+                    "league": "ENG-Premier League",
+                    "season": "2021",
+                    "game": "A-B",
+                    "game_id": 1485184,
+                }
+            ]
+        )
+    )
+    payload = {
+        "playerIdNameDictionary": {"7": "Player"},
+        "home": {"teamId": 1, "name": "Home"},
+        "away": {"teamId": 2, "name": "Away"},
+        "events": [
+            {
+                "eventId": 42,
+                "relatedEventId": 42,
+                "playerId": 7,
+                "teamId": 1,
+                "qualifiers": [],
+                "type": {"displayName": "Pass"},
+                "period": {"displayName": "FirstHalf"},
+            }
+        ],
+    }
+    instance.get = MagicMock(return_value=io.BytesIO(json.dumps(payload).encode()))
+
+    events = instance.read_events(match_id=1485184)
+
+    assert isinstance(events, pd.DataFrame)
+    assert events.iloc[0]["event_id"] == 42
+    assert events.iloc[0]["related_event_id"] == 42
 
 
 def test_validate_page_unwraps_json_in_pre():


### PR DESCRIPTION
Closes #941

WhoScored's raw `eventId` was standardized to `event_id` but then dropped by the final formatted-column selection. Preserve it so `related_event_id` can be linked back to its source event.

Test: `pytest -q tests/test_Whoscored.py -k 'preserve_event_id or validate_page'`
