### PR TITLE
fix: parse English month abbreviations without relying on locale

### DIFF
--- a/soccerdata/_common.py
+++ b/soccerdata/_common.py
@@ -23,6 +23,55 @@ from selenium.common.exceptions import JavascriptException, WebDriverException
 
 from ._config import DATA_DIR, LEAGUE_DICT, MAXAGE, TEAMNAME_REPLACEMENTS, logger
 
+# English month abbreviations used by LEAGUE_DICT's "season_start" / "season_end" values
+# (e.g. "Aug", "May"). Looked up directly instead of datetime.strptime(x, "%b"), which
+# depends on the process's current locale and raises ValueError for the very same English
+# strings on any non-English LC_TIME (see #909).
+_ENGLISH_MONTH_ABBR = {
+    "Jan": 1,
+    "Feb": 2,
+    "Mar": 3,
+    "Apr": 4,
+    "May": 5,
+    "Jun": 6,
+    "Jul": 7,
+    "Aug": 8,
+    "Sep": 9,
+    "Oct": 10,
+    "Nov": 11,
+    "Dec": 12,
+}
+
+
+def _month_from_english_abbr(name: str) -> int:
+    """Parse an English month abbreviation (e.g. "Aug") into its month number.
+
+    Locale-independent: does not use datetime.strptime or the calendar module,
+    both of which resolve "%b"/month names against the process's current
+    locale rather than always accepting English abbreviations.
+
+    Parameters
+    ----------
+    name : str
+        A three-letter English month abbreviation, e.g. "Aug".
+
+    Raises
+    ------
+    ValueError
+        If `name` is not a recognized English month abbreviation.
+
+    Returns
+    -------
+    int
+        The month number (1-12).
+    """
+    try:
+        return _ENGLISH_MONTH_ABBR[name]
+    except KeyError:
+        raise ValueError(
+            f"Invalid month abbreviation {name!r}; expected one of {list(_ENGLISH_MONTH_ABBR)}"
+        ) from None
+
 
 class SeasonCode(Enum):
     """How to interpret season codes.
@@ -60,14 +109,8 @@ class SeasonCode(Enum):
         select_league_dict = LEAGUE_DICT[league]
         if "season_code" in select_league_dict:
             return SeasonCode(select_league_dict["season_code"])
-        start_month = datetime.strptime(  # noqa: DTZ007
-            select_league_dict.get("season_start", "Aug"),
-            "%b",
-        ).month
-        end_month = datetime.strptime(  # noqa: DTZ007
-            select_league_dict.get("season_end", "May"),
-            "%b",
-        ).month
+        start_month = _month_from_english_abbr(select_league_dict.get("season_start", "Aug"))
+        end_month = _month_from_english_abbr(select_league_dict.get("season_end", "May"))
         return SeasonCode.MULTI_YEAR if (end_month - start_month) < 0 else SeasonCode.SINGLE_YEAR
 
     @staticmethod
@@ -438,9 +481,7 @@ class BaseReader(ABC):
         else:
             season_ends = datetime(
                 datetime.strptime(season[-2:], "%y").year,  # noqa: DTZ007
-                datetime.strptime(  # noqa: DTZ007
-                    league_dict["season_end"], "%b"
-                ).month,
+                _month_from_english_abbr(league_dict["season_end"]),
                 1,
                 tzinfo=timezone.utc,
             ) + relativedelta(months=1)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,6 +1,7 @@
 """Unittests for soccerdata._common."""
 
 import json
+import locale
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +13,7 @@ import soccerdata
 from soccerdata._common import (
     BaseRequestsReader,
     SeasonCode,
+    _month_from_english_abbr,
     add_alt_team_names,
     add_standardized_team_name,
     make_game_id,
@@ -321,3 +323,54 @@ def test_season_pattern4():
 def test_season_pattern5():
     assert SeasonCode.MULTI_YEAR.parse("13-14") == "1314"
     assert SeasonCode.SINGLE_YEAR.parse("13-14") == "2013"
+
+
+# _month_from_english_abbr (#909: locale-independent month parsing)
+
+
+def test_month_from_english_abbr():
+    assert _month_from_english_abbr("Jan") == 1
+    assert _month_from_english_abbr("Aug") == 8
+    assert _month_from_english_abbr("Dec") == 12
+
+
+def test_month_from_english_abbr_invalid():
+    with pytest.raises(ValueError, match="Invalid month abbreviation 'Foo'"):
+        _month_from_english_abbr("Foo")
+
+
+@pytest.fixture
+def non_english_time_locale():
+    """Switch LC_TIME to a non-English locale for the test, then always restore it.
+
+    Skips the test if the locale isn't installed on this machine (common on
+    minimal CI images), rather than failing for an unrelated reason.
+    """
+    original = locale.setlocale(locale.LC_TIME)
+    for candidate in ("es_ES.UTF-8", "es_ES", "Spanish_Spain.1252"):
+        try:
+            locale.setlocale(locale.LC_TIME, candidate)
+            break
+        except locale.Error:
+            continue
+    else:
+        pytest.skip("No Spanish LC_TIME locale available on this machine")
+    try:
+        yield
+    finally:
+        locale.setlocale(locale.LC_TIME, original)
+
+
+def test_season_code_from_league_is_locale_independent(non_english_time_locale):
+    # Regression test for #909: this used to raise
+    # ValueError: time data 'Aug' does not match format '%b'
+    # under any LC_TIME where month abbreviations aren't English.
+    assert SeasonCode.from_league("ENG-Premier League") == SeasonCode.MULTI_YEAR
+
+
+def test_is_complete_is_locale_independent(non_english_time_locale):
+    reader = BaseRequestsReader(no_store=True)
+    with time_machine.travel(datetime(2021, 7, 1, 1, 24, tzinfo=timezone.utc)):
+        # Regression test for #909, via the same "%b" parsing this method used.
+        assert reader._is_complete("ENG-Premier League", "1920")
+        assert not reader._is_complete("ENG-Premier League", "2122")


### PR DESCRIPTION
## Summary

Fixes #909.

`SeasonCode.from_league()` and `BaseRequestsReader._is_complete()` both parse `LEAGUE_DICT`'s `season_start`/`season_end` values (always English abbreviations like `"Aug"`, `"May"`) via `datetime.strptime(x, "%b")`. That directive resolves against the process's current `LC_TIME`, so under any non-English locale it raises `ValueError` on these same English strings, since e.g. `"Aug"` doesn't match a Spanish locale's month abbreviation. This matches the reported error exactly.

## Fix

As suggested in the issue thread, this parses the abbreviation without touching locale at all: a small fixed English abbreviation to month-number lookup (`_month_from_english_abbr`), used at both call sites instead of `strptime`. (Note: `calendar.month_abbr` would not have fixed this either, it's locale-sensitive the same way.)

## Testing

- Added regression tests that set `LC_TIME` to a Spanish locale and confirm `SeasonCode.from_league` and `_is_complete` both still work. Skipped automatically if that locale isn't installed on the test machine, rather than failing for an unrelated reason.
- Added direct unit tests for `_month_from_english_abbr` (valid input for all 12 months, and that invalid input raises `ValueError`).
- Ran the existing `tests/test_common.py` suite before and after this change. Two pre-existing failures (`test_add_alt_team_names`, `test_add_standardize_team_name`, both about stale team-name alias data, unrelated to date parsing) reproduce identically on unmodified `master`, confirmed not caused by this PR.