### PR TITLE
Support single-file leagues in MatchHistory

### DIFF
--- a/docs/datasources/MatchHistory.ipynb
+++ b/docs/datasources/MatchHistory.ipynb
@@ -57,6 +57,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Single-file leagues\n",
+    "\n",
+    "Some leagues publish the full match history in a single file, for example the Swiss Super League. Configure such a league with the `single_file` flag in the league dictionary:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"SUI-Super League\": {\n",
+    "    \"MatchHistory\": \"SWZ\",\n",
+    "    \"single_file\": true,\n",
+    "    \"season_start\": \"Jul\",\n",
+    "    \"season_end\": \"May\"\n",
+    "  }\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "For these leagues, `read_games` downloads the single file once and keeps only the requested seasons. The column names of the single file are mapped to the column names of the per-season files."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "id": "8dab5be9",

--- a/soccerdata/match_history.py
+++ b/soccerdata/match_history.py
@@ -1,6 +1,5 @@
 """Scraper for http://www.football-data.co.uk/data.php."""
 
-import itertools
 from collections.abc import Callable
 from pathlib import Path
 from typing import IO
@@ -8,7 +7,14 @@ from typing import IO
 import pandas as pd
 
 from ._common import BaseRequestsReader, make_game_id
-from ._config import DATA_DIR, NOCACHE, NOSTORE, TEAMNAME_REPLACEMENTS, logger
+from ._config import (
+    DATA_DIR,
+    LEAGUE_DICT,
+    NOCACHE,
+    NOSTORE,
+    TEAMNAME_REPLACEMENTS,
+    logger,
+)
 
 MATCH_HISTORY_DATA_DIR = DATA_DIR / "MatchHistory"
 MATCH_HISTORY_API = "https://www.football-data.co.uk"
@@ -22,6 +28,64 @@ MATCH_HISTORY_HEADERS = {
     "Connection": "keep-alive",
     "Upgrade-Insecure-Requests": "1",
 }
+
+
+# Some leagues (typically smaller ones, e.g. the Swiss first division) are
+# published as a single file that contains the full match history for all
+# seasons. The URL has the format "new/{league}.csv" and the file has a
+# different (subset) of columns than the per-season files.
+SINGLE_FILE_URLMASK = MATCH_HISTORY_API + "/new/{}.csv"
+# Column names used in the single-file format, mapped to the names used in
+# the per-season files.
+SINGLE_FILE_COL_RENAME = {
+    "Home": "HomeTeam",
+    "Away": "AwayTeam",
+    "HG": "FTHG",
+    "AG": "FTAG",
+    "Res": "FTR",
+}
+# Columns that are present in the per-season files but missing in the
+# single-file format. They are filled with NaN so the two formats can be
+# merged into a single DataFrame.
+SINGLE_FILE_MISSING_COLS = [
+    "Div",
+    "HTHG",
+    "HTAG",
+    "HTR",
+    "Referee",
+    "HS",
+    "AS",
+    "HST",
+    "AST",
+    "HF",
+    "AF",
+    "HC",
+    "AC",
+    "HY",
+    "AY",
+    "HR",
+    "AR",
+]
+
+
+def _season_str_to_id(season_str: str) -> str:
+    """Map a season string of the form "2012/2013" to a season id "1213"."""
+    start, end = season_str.split("/")
+    return start[-2:] + end[-2:]
+
+
+def _parse_single_file_csv(raw_data: IO[bytes], lkey: str) -> pd.DataFrame:
+    """Read a single-file league CSV and normalize it to the per-season format."""
+    df_games = pd.read_csv(raw_data, encoding="UTF-8-SIG", on_bad_lines="warn")
+    df_games = df_games.rename(columns=SINGLE_FILE_COL_RENAME)
+    df_games["Div"] = lkey
+    for col in SINGLE_FILE_MISSING_COLS:
+        if col not in df_games.columns:
+            df_games[col] = pd.NA
+    # drop the single-file specific columns after extracting the season
+    df_games["season"] = df_games["Season"].map(_season_str_to_id)
+    df_games = df_games.drop(columns=["Country", "League", "Season"])
+    return df_games
 
 
 def _parse_csv(raw_data: IO[bytes], lkey: str, skey: str) -> pd.DataFrame:
@@ -113,18 +177,34 @@ class MatchHistory(BaseRequestsReader):
         }
 
         df_list = []
-        for lkey, skey in itertools.product(self._selected_leagues.values(), self.seasons):
-            filepath = self.data_dir / filemask.format(lkey, skey)
-            url = urlmask.format(skey, lkey)
-            current_season = not self._is_complete(lkey, skey)
+        for canonical, lkey in self._selected_leagues.items():
+            if LEAGUE_DICT[canonical].get("single_file", False):
+                # Leagues that publish the full match history in a single file
+                # (one row per match across all seasons) instead of one file
+                # per season.
+                filepath = self.data_dir / f"{lkey}.csv"
+                url = SINGLE_FILE_URLMASK.format(lkey)
+                current_season = any(
+                    not self._is_complete(canonical, skey) for skey in self.seasons
+                )
+                reader = self.get(url, filepath, no_cache=current_season)
+                df_games = _parse_single_file_csv(reader, lkey)
+                df_games = df_games[df_games["season"].isin(self.seasons)]
+                df_list.append(df_games)
+            else:
+                # Leagues that publish a separate file for each season.
+                for skey in self.seasons:
+                    filepath = self.data_dir / filemask.format(lkey, skey)
+                    url = urlmask.format(skey, lkey)
+                    current_season = not self._is_complete(canonical, skey)
 
-            reader = self.get(url, filepath, no_cache=current_season)
-            df_games = _parse_csv(reader, lkey, skey).assign(season=skey)
+                    reader = self.get(url, filepath, no_cache=current_season)
+                    df_games = _parse_csv(reader, lkey, skey).assign(season=skey)
 
-            if "Time" not in df_games.columns:
-                df_games["Time"] = "12:00"
-            df_games["Time"] = df_games["Time"].fillna("12:00")
-            df_list.append(df_games)
+                    if "Time" not in df_games.columns:
+                        df_games["Time"] = "12:00"
+                    df_games["Time"] = df_games["Time"].fillna("12:00")
+                    df_list.append(df_games)
 
         df = (
             pd.concat(df_list, sort=False)

--- a/tests/test_MatchHistory.py
+++ b/tests/test_MatchHistory.py
@@ -1,7 +1,11 @@
 """Unittests for class soccerdata.MatchHistory."""
 
-import pandas as pd
+from pathlib import Path
 
+import pandas as pd
+import pytest
+
+from soccerdata import _config
 from soccerdata.match_history import MatchHistory
 
 
@@ -12,3 +16,46 @@ def test_read_games(match_epl_5y: MatchHistory) -> None:
     assert len(df.index.get_level_values("season").unique()) == 5
     assert len(df) > 0
     assert not any("ï»¿" in c for c in df.columns)
+
+
+def test_read_games_single_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """It should load leagues that publish all seasons in a single file.
+
+    Some leagues (typically smaller ones) are published by football-data.co.uk
+    in a single file under "/new/{league}.csv" that contains the full match
+    history across all seasons, using different column names than the
+    per-season files. See https://github.com/probberechts/soccerdata/issues/589
+    """
+    csv_content = (
+        "Country,League,Season,Date,Time,Home,Away,HG,AG,Res,PSCH,PSCD,PSCA\n"
+        "Switzerland,Super League,2021/2022,07/08/2021,18:00,Basel,Zurich,2,1,H,2.10,3.40,3.90\n"
+        "Switzerland,Super League,2021/2022,08/08/2021,16:00,Lausanne,Sion,0,0,D,2.20,3.10,3.50\n"
+        "Switzerland,Super League,2022/2023,06/08/2022,18:00,Geneve,Bern,1,0,H,2.00,3.50,4.00\n"
+    )
+    # cached copy of https://www.football-data.co.uk/new/SWZ.csv
+    (tmp_path / "SWZ.csv").write_bytes(csv_content.encode("utf-8-sig"))
+
+    monkeypatch.setitem(
+        _config.LEAGUE_DICT,
+        "SUI-Super League",
+        {
+            "MatchHistory": "SWZ",
+            "single_file": True,
+            "season_start": "Jul",
+            "season_end": "May",
+        },
+    )
+    monkeypatch.delattr(MatchHistory, "_all_leagues_dict", raising=False)
+
+    mh = MatchHistory("SUI-Super League", seasons=["2122"], data_dir=tmp_path)
+    df = mh.read_games()
+
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2
+    assert list(df.index.get_level_values("season").unique()) == ["2122"]
+    assert list(df["home_team"]) == ["Basel", "Lausanne"]
+    assert list(df["away_team"]) == ["Zurich", "Sion"]
+    # shared columns are kept; per-season-only columns are filled with NaN
+    assert "PSCD" in df.columns
+    assert df["HTR"].isna().all()
+    assert df["referee"].isna().all()


### PR DESCRIPTION
## Summary

Football-data.co.uk publishes some leagues in a single file. The file holds the full match history for all seasons. The Swiss Super League is an example. These files live at `/new/{league}.csv`. They use a different subset of column names than the per-season files.

`MatchHistory` currently reads only the per-season files at `/mmz4281/{season}/{league}.csv`. For a single-file league, this URL does not exist. The request returns a 404. This change fixes issue #589.

## What changed

- The change adds a `single_file` flag to the league config.
- For a single-file league, `read_games` downloads `/new/{league}.csv` once. It does not loop over the seasons.
- It maps the single-file column names to the per-season column names. It fills the missing columns with NaN.
- It filters the rows to the requested seasons.

## How to use

Add a custom league to `league_dict.json` with the `single_file` flag:

```json
{
  "SUI-Super League": {
    "MatchHistory": "SWZ",
    "single_file": true,
    "season_start": "Jul",
    "season_end": "May"
  }
}
```

## Tests

Added `test_read_games_single_file`. It uses a synthetic fixture file. It does not hit the network.

## Documentation

Updated `docs/datasources/MatchHistory.ipynb`.

---

Fixes #589